### PR TITLE
update basic_response and maintain user api

### DIFF
--- a/api/src/main/java/grooteogi/controller/HashtagController.java
+++ b/api/src/main/java/grooteogi/controller/HashtagController.java
@@ -6,7 +6,6 @@ import grooteogi.dto.response.BasicResponse;
 import grooteogi.service.HashtagService;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -26,22 +25,19 @@ public class HashtagController {
   public ResponseEntity<BasicResponse> getAllHashtag() {
     List<Hashtag> hashtagList = hashtagService.getAllHashtag();
     return ResponseEntity.ok(
-        BasicResponse.builder().status(HttpStatus.OK.value()).count(hashtagList.size())
-            .data(hashtagList).build());
+        BasicResponse.builder().count(hashtagList.size()).data(hashtagList).build());
   }
 
   @GetMapping("/top10")
   public ResponseEntity<BasicResponse> getTopTenHashtag(@RequestParam String type) {
     List<Hashtag> hashtagList = hashtagService.getTopTenHashtag(type);
     return ResponseEntity.ok(
-        BasicResponse.builder().status(HttpStatus.OK.value()).count(hashtagList.size())
-            .data(hashtagList).build());
+        BasicResponse.builder().count(hashtagList.size()).data(hashtagList).build());
   }
 
   @PostMapping
   public ResponseEntity<BasicResponse> createHashtag(@RequestBody HashtagDto hashtagDto) {
     Hashtag createdHashtag = this.hashtagService.createHashtag(hashtagDto);
-    return ResponseEntity.ok(
-        BasicResponse.builder().status(HttpStatus.OK.value()).data(createdHashtag).build());
+    return ResponseEntity.ok(BasicResponse.builder().data(createdHashtag).build());
   }
 }

--- a/api/src/main/java/grooteogi/controller/UserController.java
+++ b/api/src/main/java/grooteogi/controller/UserController.java
@@ -49,7 +49,7 @@ public class UserController {
             .data(userList).build());
   }
 
-  @GetMapping("/{user_id}")
+  @GetMapping("/{userId}")
   public ResponseEntity<BasicResponse> getUser(@PathVariable Integer userId) {
     User user = userService.getUser(userId);
 

--- a/api/src/main/java/grooteogi/controller/UserController.java
+++ b/api/src/main/java/grooteogi/controller/UserController.java
@@ -23,7 +23,6 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.validation.BindingResult;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -53,14 +52,11 @@ public class UserController {
     return ResponseEntity.ok(BasicResponse.builder().data(user).build());
   }
 
-  @PatchMapping("/{userId}")
-  public ResponseEntity patchUser(@PathVariable Integer userId) {
-    return ResponseEntity.ok(null);
-  }
-
   @DeleteMapping("/{userId}")
   public ResponseEntity deleteUser(@PathVariable Integer userId) {
-    return ResponseEntity.ok(null);
+    userService.withdrawal(userId);
+
+    return ResponseEntity.ok(BasicResponse.builder().build());
   }
 
   /*

--- a/api/src/main/java/grooteogi/controller/UserController.java
+++ b/api/src/main/java/grooteogi/controller/UserController.java
@@ -19,7 +19,6 @@ import javax.servlet.http.HttpServletRequest;
 import javax.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpHeaders;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.BindingResult;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -44,17 +43,14 @@ public class UserController {
   public ResponseEntity<BasicResponse> getAllUser() {
     List<User> userList = userService.getAllUser();
 
-    return ResponseEntity.ok(
-        BasicResponse.builder().status(HttpStatus.OK.value()).count(userList.size())
-            .data(userList).build());
+    return ResponseEntity.ok(BasicResponse.builder().count(userList.size()).data(userList).build());
   }
 
   @GetMapping("/{userId}")
   public ResponseEntity<BasicResponse> getUser(@PathVariable Integer userId) {
     User user = userService.getUser(userId);
 
-    return ResponseEntity.ok(
-        BasicResponse.builder().status(HttpStatus.OK.value()).data(user).build());
+    return ResponseEntity.ok(BasicResponse.builder().data(user).build());
   }
 
   @PatchMapping("/{userId}")
@@ -84,8 +80,8 @@ public class UserController {
 
     emailService.createEmailVerification(email);
 
-    return ResponseEntity.ok(BasicResponse.builder().status(HttpStatus.OK.value())
-        .message("send email verification success").build());
+    return ResponseEntity.ok(
+        BasicResponse.builder().message("send email verification success").build());
   }
 
   /*
@@ -99,7 +95,7 @@ public class UserController {
       throw new ApiException(ApiExceptionEnum.EXPIRED_TOKEN_EXCEPTION);
     }
 
-    return ResponseEntity.ok(BasicResponse.builder().status(HttpStatus.OK.value()).build());
+    return ResponseEntity.ok(BasicResponse.builder().build());
   }
 
   /*
@@ -116,8 +112,7 @@ public class UserController {
 
     User user = userService.register(userDto);
 
-    return ResponseEntity.ok(
-        BasicResponse.builder().status(HttpStatus.OK.value()).data(user).build());
+    return ResponseEntity.ok(BasicResponse.builder().data(user).build());
   }
 
   @PostMapping("/login")
@@ -128,8 +123,7 @@ public class UserController {
       throw new ApiException(ApiExceptionEnum.BAD_REQUEST_EXCEPTION);
     }
 
-    return ResponseEntity.ok(
-        BasicResponse.builder().status(HttpStatus.OK.value()).data(token).build());
+    return ResponseEntity.ok(BasicResponse.builder().data(token).build());
   }
 
   @PostMapping("/oauth/register")
@@ -142,8 +136,7 @@ public class UserController {
 
     User user = userService.register(userDto);
 
-    return ResponseEntity.ok(
-        BasicResponse.builder().status(HttpStatus.OK.value()).data(user).build());
+    return ResponseEntity.ok(BasicResponse.builder().data(user).build());
   }
 
   @PostMapping("/oauth/login")
@@ -154,8 +147,7 @@ public class UserController {
       throw new ApiException(ApiExceptionEnum.BAD_REQUEST_EXCEPTION);
     }
 
-    return ResponseEntity.ok(
-        BasicResponse.builder().status(HttpStatus.OK.value()).data(token).build());
+    return ResponseEntity.ok(BasicResponse.builder().data(token).build());
   }
 
   @GetMapping("/token/verify")
@@ -169,8 +161,7 @@ public class UserController {
 
     User user = userService.getUser(Integer.parseInt(result.get("ID").toString()));
 
-    return ResponseEntity.ok(
-        BasicResponse.builder().status(HttpStatus.OK.value()).data(user).build());
+    return ResponseEntity.ok(BasicResponse.builder().data(user).build());
   }
 
   @GetMapping("/token/refresh")
@@ -187,7 +178,6 @@ public class UserController {
     returnValue.put("token", result.get("token").toString());
     returnValue.put("user", userService.getUser(Integer.parseInt(result.get("ID").toString())));
 
-    return ResponseEntity.ok(
-        BasicResponse.builder().status(HttpStatus.OK.value()).data(returnValue).build());
+    return ResponseEntity.ok(BasicResponse.builder().data(returnValue).build());
   }
 }

--- a/api/src/main/java/grooteogi/controller/UserHashtagController.java
+++ b/api/src/main/java/grooteogi/controller/UserHashtagController.java
@@ -11,7 +11,6 @@ import grooteogi.dto.response.BasicResponse;
 import grooteogi.service.UserHashtagService;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -33,8 +32,7 @@ public class UserHashtagController {
   public ResponseEntity<BasicResponse> saveUserHashtag(@RequestBody UserHashtagDto userHashtagDto) {
     List<UserHashtag> hashtagList = userHashtagService.saveUserHashtag(userHashtagDto);
     return ResponseEntity.ok(
-        BasicResponse.builder().status(HttpStatus.OK.value()).count(hashtagList.size())
-            .data(hashtagList).build());
+        BasicResponse.builder().count(hashtagList.size()).data(hashtagList).build());
   }
 
   @DeleteMapping("/hashtag")
@@ -42,23 +40,20 @@ public class UserHashtagController {
       int[] hashtagId) {
     List<UserHashtag> hashtagList = userHashtagService.deleteUserHashtag(userId, hashtagId);
     return ResponseEntity.ok(
-        BasicResponse.builder().status(HttpStatus.OK.value()).count(hashtagList.size())
-            .data(hashtagList).build());
+        BasicResponse.builder().count(hashtagList.size()).data(hashtagList).build());
   }
 
   @GetMapping("/hashtag")
   public ResponseEntity<BasicResponse> getAllUserHashtag() {
     List<UserHashtag> hashtagList = userHashtagService.getAllUserHashtag();
     return ResponseEntity.ok(
-        BasicResponse.builder().status(HttpStatus.OK.value()).count(hashtagList.size())
-            .data(hashtagList).build());
+        BasicResponse.builder().count(hashtagList.size()).data(hashtagList).build());
   }
 
   @GetMapping("/{userId}/hashtag")
   public ResponseEntity<BasicResponse> getUserHashtag(@PathVariable int userId) {
     List<UserHashtag> hashtagList = userHashtagService.getUserHashtag(userId);
     return ResponseEntity.ok(
-        BasicResponse.builder().status(HttpStatus.OK.value()).count(hashtagList.size())
-            .data(hashtagList).build());
+        BasicResponse.builder().count(hashtagList.size()).data(hashtagList).build());
   }
 }

--- a/api/src/main/java/grooteogi/dto/response/BasicResponse.java
+++ b/api/src/main/java/grooteogi/dto/response/BasicResponse.java
@@ -4,6 +4,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import org.springframework.http.HttpStatus;
 
 @Data
 @Builder
@@ -11,7 +12,8 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 public class BasicResponse {
 
-  private Integer status;
+  private final Integer status = HttpStatus.OK.value();
+
   private String message;
   private Integer count;
   private Object data;

--- a/api/src/main/java/grooteogi/service/UserService.java
+++ b/api/src/main/java/grooteogi/service/UserService.java
@@ -37,6 +37,14 @@ public class UserService {
     return user.get();
   }
 
+  public void withdrawal(int userId) {
+    Optional<User> user = userRepository.findById(userId);
+    if (user.isEmpty()) {
+      throw new ApiException(ApiExceptionEnum.USER_NOT_FOUND_EXCEPTION);
+    }
+    userRepository.delete(user.get());
+  }
+
   public User register(UserDto userDto) {
     switch (userDto.getType()) {
       case GENERAL:


### PR DESCRIPTION
## 개요
update basic_response and maintain user api

## 작업내용
-  BasicResponse에서 status를 HttpStatus.OK로 지정
    -  더 이상 builder로 값 대입하지 않아도 됨
- get_user 메서드에서 받는 잘못 지정된 path variable 수정
- delete_user 메서드 구현
- patch_user 메서드 삭제

