### PR TITLE
Return headers including token when user login

### DIFF
--- a/api/src/main/java/grooteogi/controller/UserController.java
+++ b/api/src/main/java/grooteogi/controller/UserController.java
@@ -15,10 +15,14 @@ import grooteogi.service.UserService;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import javax.servlet.http.Cookie;
 import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
 import javax.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseCookie;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.BindingResult;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -114,12 +118,15 @@ public class UserController {
   @PostMapping("/login")
   public ResponseEntity<BasicResponse> login(@RequestBody LoginDto loginDto) {
     Token token = userService.login(loginDto);
+    User user = userService.getUserByEmail(loginDto.getEmail());
 
-    if (token == null) {
-      throw new ApiException(ApiExceptionEnum.BAD_REQUEST_EXCEPTION);
-    }
+    HttpHeaders responseHeaders = new HttpHeaders();
+    responseHeaders.set("X-AUTH-TOKEN", token.getAccessToken());
+    responseHeaders.set("X-REFRESH-TOKEN", token.getRefreshToken());
 
-    return ResponseEntity.ok(BasicResponse.builder().data(token).build());
+    return new ResponseEntity<>(
+        BasicResponse.builder().data(user).build(), responseHeaders, HttpStatus.OK
+    );
   }
 
   @PostMapping("/oauth/register")
@@ -138,12 +145,15 @@ public class UserController {
   @PostMapping("/oauth/login")
   public ResponseEntity<BasicResponse> oauthLogin(@RequestBody LoginDto loginDto) {
     Token token = userService.login(loginDto);
+    User user = userService.getUserByEmail(loginDto.getEmail());
 
-    if (token == null) {
-      throw new ApiException(ApiExceptionEnum.BAD_REQUEST_EXCEPTION);
-    }
+    HttpHeaders responseHeaders = new HttpHeaders();
+    responseHeaders.set("X-AUTH-TOKEN", token.getAccessToken());
+    responseHeaders.set("X-REFRESH-TOKEN", token.getRefreshToken());
 
-    return ResponseEntity.ok(BasicResponse.builder().data(token).build());
+    return new ResponseEntity<>(
+        BasicResponse.builder().data(user).build(), responseHeaders, HttpStatus.OK
+    );
   }
 
   @GetMapping("/token/verify")

--- a/api/src/main/java/grooteogi/exception/ApiExceptionEnum.java
+++ b/api/src/main/java/grooteogi/exception/ApiExceptionEnum.java
@@ -18,6 +18,7 @@ public enum ApiExceptionEnum {
   INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버가 응답하지 않습니다."),
 
   // Custom Exception
+  LOGIN_FAIL_EXCEPTION(HttpStatus.NOT_FOUND, "로그인에 실패하였습니다."),
   USER_NOT_FOUND_EXCEPTION(HttpStatus.NOT_FOUND, "유저를 찾을 수 없습니다."),
   EMAIL_DUPLICATION_EXCEPTION(HttpStatus.CONFLICT, "이미 존재하는 이메일입니다."),
   EXPIRED_TOKEN_EXCEPTION(HttpStatus.INSUFFICIENT_SPACE_ON_RESOURCE, "만료된 토큰입니다."), //419

--- a/api/src/main/java/grooteogi/repository/UserRepository.java
+++ b/api/src/main/java/grooteogi/repository/UserRepository.java
@@ -1,12 +1,13 @@
 package grooteogi.repository;
 
 import grooteogi.domain.User;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface UserRepository extends JpaRepository<User, Integer> {
 
   boolean existsByEmail(String email);
 
-  User findByEmail(String email);
+  Optional<User> findByEmail(String email);
 
 }

--- a/api/src/main/java/grooteogi/service/UserService.java
+++ b/api/src/main/java/grooteogi/service/UserService.java
@@ -37,6 +37,14 @@ public class UserService {
     return user.get();
   }
 
+  public User getUserByEmail(String email) {
+    Optional<User> user = userRepository.findByEmail(email);
+    if (user.isEmpty()) {
+      throw new ApiException(ApiExceptionEnum.USER_NOT_FOUND_EXCEPTION);
+    }
+    return user.get();
+  }
+
   public void withdrawal(int userId) {
     Optional<User> user = userRepository.findById(userId);
     if (user.isEmpty()) {
@@ -68,14 +76,13 @@ public class UserService {
   }
 
   public Token login(LoginDto loginDto) {
-    User user = userRepository.findByEmail(loginDto.getEmail());
+    User user = getUserByEmail(loginDto.getEmail());
     if (loginDto.getPassword().isBlank()) {
       return generateToken(user.getId(), loginDto.getEmail());
-    }
-    if (passwordEncoder.matches(loginDto.getPassword(), user.getPassword())) {
+    } else if (passwordEncoder.matches(loginDto.getPassword(), user.getPassword())) {
       return generateToken(user.getId(), loginDto.getEmail());
     } else {
-      return null;
+      throw new ApiException(ApiExceptionEnum.LOGIN_FAIL_EXCEPTION);
     }
   }
 


### PR DESCRIPTION
## 개요
로그인 시 token을 json이 아닌 header에 담아서 전달

## 작업내용
- ResponseEntity 전송 시 header와 함께 전달
- 로그인 시 return null 삭제

## 주의사항
- ReponseEntity builder()시에는 header가 들어가지 않아 new를 이용
- 추후 확인 후 수정이 필요할 수도 있음
