### PR TITLE
Deal with errors when login using kakao

### DIFF
--- a/api/src/main/java/grooteogi/utils/JwtProvider.java
+++ b/api/src/main/java/grooteogi/utils/JwtProvider.java
@@ -56,7 +56,7 @@ public class JwtProvider {
       result.put("status", ApiExceptionEnum.EXPIRED_TOKEN_EXCEPTION);
     } catch (JwtException e) {
       result.put("result", false);
-      result.put("status", ApiExceptionEnum.BAD_REQUEST_EXCEPTION);
+      result.put("status", ApiExceptionEnum.UNAUTHORIZED_EXCEPTION);
     }
 
     return result;

--- a/api/src/main/java/grooteogi/utils/OauthClient.java
+++ b/api/src/main/java/grooteogi/utils/OauthClient.java
@@ -1,7 +1,5 @@
 package grooteogi.utils;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
@@ -9,17 +7,9 @@ import grooteogi.dto.OauthDto;
 import grooteogi.dto.UserDto;
 import grooteogi.exception.ApiException;
 import grooteogi.exception.ApiExceptionEnum;
-import java.io.BufferedReader;
-import java.io.BufferedWriter;
-import java.io.IOException;
-import java.io.InputStreamReader;
-import java.io.OutputStreamWriter;
-import java.net.HttpURLConnection;
-import java.net.URL;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.boot.test.autoconfigure.web.client.AutoConfigureWebClient;
 import org.springframework.boot.web.client.RestTemplateBuilder;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
@@ -56,7 +46,7 @@ public class OauthClient {
     params.add("grant_type", "authorization_code");
     params.add("client_id", kakaoClientId);
     params.add("client_secret", kakaoClientSecret);
-    params.add("redirect_uri", "http://localhost:8080/user/oauth");
+    params.add("redirect_uri", "http://localhost:8080/user/oauth/kakao");
     params.add("code", oauthDto.getCode());
 
     HttpEntity<MultiValueMap<String, String>> request = new HttpEntity<>(params, headers);


### PR DESCRIPTION
## 개요
kakao와 google의 oauth router 분리

## 작업내용
- OAuth kakao redirect uri 변경

## 주의사항
- 카카오 간편 로그인 시 허용 IP가 제한되기 때문에 간편 로그인 테스트 전 말해야 한다.
