### PR TITLE
create modify user hashtag api

### DIFF
--- a/api/src/main/java/grooteogi/controller/UserHashtagController.java
+++ b/api/src/main/java/grooteogi/controller/UserHashtagController.java
@@ -16,6 +16,7 @@ import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -27,21 +28,6 @@ import org.springframework.web.bind.annotation.RestController;
 public class UserHashtagController {
 
   private final UserHashtagService userHashtagService;
-
-  @PostMapping("/hashtag")
-  public ResponseEntity<BasicResponse> saveUserHashtag(@RequestBody UserHashtagDto userHashtagDto) {
-    List<UserHashtag> hashtagList = userHashtagService.saveUserHashtag(userHashtagDto);
-    return ResponseEntity.ok(
-        BasicResponse.builder().count(hashtagList.size()).data(hashtagList).build());
-  }
-
-  @DeleteMapping("/hashtag")
-  public ResponseEntity<BasicResponse> deleteUserHashtag(@RequestParam int userId,
-      int[] hashtagId) {
-    List<UserHashtag> hashtagList = userHashtagService.deleteUserHashtag(userId, hashtagId);
-    return ResponseEntity.ok(
-        BasicResponse.builder().count(hashtagList.size()).data(hashtagList).build());
-  }
 
   @GetMapping("/hashtag")
   public ResponseEntity<BasicResponse> getAllUserHashtag() {
@@ -56,4 +42,29 @@ public class UserHashtagController {
     return ResponseEntity.ok(
         BasicResponse.builder().count(hashtagList.size()).data(hashtagList).build());
   }
+
+  @PostMapping("/hashtag")
+  public ResponseEntity<BasicResponse> saveUserHashtag(@RequestBody UserHashtagDto userHashtagDto) {
+    List<UserHashtag> hashtagList = userHashtagService.saveUserHashtag(userHashtagDto);
+    return ResponseEntity.ok(
+        BasicResponse.builder().count(hashtagList.size()).data(hashtagList).build());
+  }
+
+  @PutMapping("/hashtag")
+  public ResponseEntity<BasicResponse> modifyUserHashtag(
+      @RequestBody UserHashtagDto userHashtagDto) {
+    List<UserHashtag> hashtagList = userHashtagService.modifyUserHashtag(userHashtagDto);
+    return ResponseEntity.ok(
+        BasicResponse.builder().count(hashtagList.size()).data(hashtagList).build());
+  }
+
+  @DeleteMapping("/hashtag")
+  public ResponseEntity<BasicResponse> deleteUserHashtag(@RequestParam int userId,
+      int[] hashtagId) {
+    List<UserHashtag> hashtagList = userHashtagService.deleteUserHashtag(userId, hashtagId);
+    return ResponseEntity.ok(
+        BasicResponse.builder().count(hashtagList.size()).data(hashtagList).build());
+  }
+
+
 }

--- a/api/src/main/java/grooteogi/domain/UserHashtag.java
+++ b/api/src/main/java/grooteogi/domain/UserHashtag.java
@@ -1,6 +1,7 @@
 package grooteogi.domain;
 
 import com.fasterxml.jackson.annotation.JsonBackReference;
+import com.fasterxml.jackson.annotation.JsonManagedReference;
 import java.sql.Timestamp;
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
@@ -30,7 +31,7 @@ public class UserHashtag {
   private User user;
 
   @ManyToOne
-  @JsonBackReference
+  @JsonManagedReference
   @JoinColumn(name = "hashtag_id")
   private Hashtag hashtag;
 }

--- a/api/src/main/java/grooteogi/dto/UserHashtagDto.java
+++ b/api/src/main/java/grooteogi/dto/UserHashtagDto.java
@@ -12,6 +12,6 @@ public class UserHashtagDto {
   private Integer userId;
 
   @NotBlank(message = "hashtag id를 입력하세요.")
-  private Integer[] hashtagId;
+  private Integer[] hashtagIds;
 
 }

--- a/api/src/main/java/grooteogi/exception/ApiExceptionEnum.java
+++ b/api/src/main/java/grooteogi/exception/ApiExceptionEnum.java
@@ -28,7 +28,8 @@ public enum ApiExceptionEnum {
   S3_UPLOAD_FAIL_EXCEPTION(HttpStatus.BAD_REQUEST, "파일 업로드에 실패했습니다."), //
   DUPLICATION_VALUE_EXCEPTION(HttpStatus.CONFLICT, "이미 존재하는 값입니다."),
   USERHASHTAG_NOT_FOUND_EXCEPTION(HttpStatus.NOT_FOUND, "저장된 해당 사용자 해시태그가 없습니다."),
-  POST_NOT_FOUND_EXCEPTION(HttpStatus.NOT_FOUND, "저장된 해당 포스트가 없습니다.");
+  POST_NOT_FOUND_EXCEPTION(HttpStatus.NOT_FOUND, "저장된 해당 포스트가 없습니다."),
+  HASHTAG_NOT_FOUND_EXCEPTION(HttpStatus.NOT_FOUND, "저장된 해당 해시태그가 없습니다.");
 
   private final HttpStatus httpStatus;
   private final Integer status;

--- a/api/src/main/java/grooteogi/service/HashtagService.java
+++ b/api/src/main/java/grooteogi/service/HashtagService.java
@@ -49,4 +49,5 @@ public class HashtagService {
     return this.hashtagRepository.save(createdHashtag);
   }
 
+
 }


### PR DESCRIPTION
### ## Related Issue
[FEAT] Create modify userHashtag API

### ## Description
유저 프로필 내 해시태그 수정
해시태그 관련 예외처리 추가

- 기존 유저 해시태그 List와 입력받은 해시태그 List 비교
- 추가된 해시태그에 대한 count 증가, 삭제된 해시태그에 대한 count 감소
- POST API와 PUT API에서 존재하지 않는 해시태그가 들어왔을 때 
HASHTAG_NOT_FOUND_EXCEPTION 예외 발생

### ## Changes
- UserHashtag 도메인에서 Hashtag Column Annotation @JsonManagedReference로 변경 (API response에서 해시태그 상세 조회 가능) 
- UserHashtag 서비스에서 Get, Post, Put, Delete 순으로 메소드 위치 변경
- UserhastagDto에서 hashtagId -> hashtagIds로 변경
- ApiExceptionEnum에 HASHTAG_NOT_FOUND_EXCEPTION 추가

### ## Note
전에 PR 했던 게 몇 개 겹치는 것 같은데 이번 PR 내용 확인해주시고 저번 거는 무시해주세요!