### PR TITLE
Fix: signature does not match in aws s3 config

### DIFF
--- a/api/src/main/java/grooteogi/config/AwsS3Config.java
+++ b/api/src/main/java/grooteogi/config/AwsS3Config.java
@@ -11,10 +11,11 @@ import org.springframework.context.annotation.Configuration;
 
 @Configuration
 public class AwsS3Config {
-  @Value("${cloud.aws.credentials.access-key}")
+
+  @Value("${AWS_ACCESS_KEY}")
   private String accessKey;
 
-  @Value("${cloud.aws.credentials.secret-key}")
+  @Value("${AWS_SECRET_KEY}")
   private String secretKey;
 
   @Value("${cloud.aws.region.static}")
@@ -23,10 +24,8 @@ public class AwsS3Config {
   @Bean
   public AmazonS3Client amazonS3Client() {
     AWSCredentials awsCredentials = new BasicAWSCredentials(accessKey, secretKey);
-    return (AmazonS3Client) AmazonS3ClientBuilder
-        .standard()
-        .withCredentials(new AWSStaticCredentialsProvider(awsCredentials))
-        .withRegion(region)
+    return (AmazonS3Client) AmazonS3ClientBuilder.standard()
+        .withCredentials(new AWSStaticCredentialsProvider(awsCredentials)).withRegion(region)
         .build();
   }
 }

--- a/api/src/main/java/grooteogi/config/AwsS3Config.java
+++ b/api/src/main/java/grooteogi/config/AwsS3Config.java
@@ -7,7 +7,9 @@ import com.amazonaws.services.s3.AmazonS3Client;
 import com.amazonaws.services.s3.AmazonS3ClientBuilder;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
 
+@Configuration
 public class AwsS3Config {
   @Value("${cloud.aws.credentials.access-key}")
   private String accessKey;

--- a/api/src/main/resources/application.yml
+++ b/api/src/main/resources/application.yml
@@ -16,14 +16,11 @@ spring:
     secret: ${JWT_KEY}
   session:
     timeout: 300
-    store-type : redis
+    store-type: redis
     redis:
       namespace: spring:session
 cloud:
   aws:
-    credentials:
-      access-key: ${AWS_ACCESS_KEY}
-      secret-key: $(AWS_SECRET_KEY}
     region:
       static: ${AWS_REGION_NAME}
     s3:


### PR DESCRIPTION
## Related Issue
#64 [BUG] SignatureDoesNotMatch in AwsS3Config

## Description
`AwsS3Config`에서 환경변수로 설정한 엑세스키와 시크릿키를 불러오지 못하는 문제

## Changes
- `configuration` 어노테이션  `AwsS3Config`에 추가
- AwsS3Config에서 `AWS_ACCESS_KEY`와 `AWS_SECRET_KEY`를 직접 불러오도록 수정

## Note
