### PR TITLE
FIX get reservation

### DIFF
--- a/api/src/main/java/grooteogi/controller/ReservationController.java
+++ b/api/src/main/java/grooteogi/controller/ReservationController.java
@@ -21,9 +21,12 @@ import org.springframework.web.bind.annotation.RestController;
 public class ReservationController {
   private final ReservationService reservationService;
 
+  /*
+  * 내가 호스트인 약속 리스트
+  * */
   @GetMapping("/post")
-  public ResponseEntity<BasicResponse> getAllReservation() {
-    List<Reservation> reservationList = this.reservationService.getAllReservation();
+  public ResponseEntity<BasicResponse> getPostReservation() {
+    List<Reservation> reservationList = this.reservationService.getPostReservation();
     return ResponseEntity.ok(BasicResponse.builder().data(reservationList).build());
   }
 
@@ -33,6 +36,9 @@ public class ReservationController {
     return ResponseEntity.ok(BasicResponse.builder().data(reservation).build());
   }
 
+  /*
+  * 내가 잡은 약속 리스트
+  * */
   @GetMapping("/apply/{userId}")
   public ResponseEntity<BasicResponse> getUserReservation(@PathVariable Integer userId) {
     List<Reservation> reservations = reservationService.getUserReservation(userId);

--- a/api/src/main/java/grooteogi/controller/ReservationController.java
+++ b/api/src/main/java/grooteogi/controller/ReservationController.java
@@ -2,11 +2,14 @@ package grooteogi.controller;
 
 import grooteogi.domain.Reservation;
 import grooteogi.dto.ReservationDto;
+import grooteogi.dto.ReservationRes;
 import grooteogi.response.BasicResponse;
 import grooteogi.service.ReservationService;
+import grooteogi.utils.Session;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -21,12 +24,9 @@ import org.springframework.web.bind.annotation.RestController;
 public class ReservationController {
   private final ReservationService reservationService;
 
-  /*
-  * 내가 호스트인 약속 리스트
-  * */
   @GetMapping("/post")
   public ResponseEntity<BasicResponse> getPostReservation() {
-    List<Reservation> reservationList = this.reservationService.getPostReservation();
+    List<ReservationRes> reservationList = this.reservationService.getPostReservation();
     return ResponseEntity.ok(BasicResponse.builder().data(reservationList).build());
   }
 
@@ -36,19 +36,21 @@ public class ReservationController {
     return ResponseEntity.ok(BasicResponse.builder().data(reservation).build());
   }
 
-  /*
-  * 내가 잡은 약속 리스트
-  * */
-  @GetMapping("/apply/{userId}")
-  public ResponseEntity<BasicResponse> getUserReservation(@PathVariable Integer userId) {
-    List<Reservation> reservations = reservationService.getUserReservation(userId);
+  @GetMapping("/apply")
+  public ResponseEntity<BasicResponse> getUserReservation() {
+    Session session = (Session) SecurityContextHolder.getContext()
+        .getAuthentication().getPrincipal();
+    List<Reservation> reservations = reservationService.getUserReservation(session.getId());
     return ResponseEntity.ok(BasicResponse.builder().data(reservations).build());
   }
 
   @PostMapping
   public ResponseEntity<BasicResponse> createReservation(
       @RequestBody ReservationDto reservationDto) {
-    Reservation createdReservation = this.reservationService.createReservation(reservationDto);
+    Session session = (Session) SecurityContextHolder.getContext()
+        .getAuthentication().getPrincipal();
+    Reservation createdReservation = reservationService
+        .createReservation(reservationDto, session.getId());
     return ResponseEntity.ok(BasicResponse.builder().data(createdReservation).build());
   }
 

--- a/api/src/main/java/grooteogi/controller/ReservationController.java
+++ b/api/src/main/java/grooteogi/controller/ReservationController.java
@@ -26,13 +26,15 @@ public class ReservationController {
 
   @GetMapping("/post")
   public ResponseEntity<BasicResponse> getPostReservation() {
-    List<ReservationRes> reservationList = this.reservationService.getPostReservation();
+    Session session = (Session) SecurityContextHolder.getContext()
+        .getAuthentication().getPrincipal();
+    List<ReservationRes> reservationList = reservationService.getPostReservation(session.getId());
     return ResponseEntity.ok(BasicResponse.builder().data(reservationList).build());
   }
 
   @GetMapping("/{reservationId}")
   public ResponseEntity<BasicResponse> getReservation(@PathVariable Integer reservationId) {
-    Reservation reservation = this.reservationService.getReservation(reservationId);
+    Reservation reservation = reservationService.getReservation(reservationId);
     return ResponseEntity.ok(BasicResponse.builder().data(reservation).build());
   }
 

--- a/api/src/main/java/grooteogi/domain/Reservation.java
+++ b/api/src/main/java/grooteogi/domain/Reservation.java
@@ -2,7 +2,6 @@ package grooteogi.domain;
 
 import com.fasterxml.jackson.annotation.JsonBackReference;
 import java.sql.Timestamp;
-import javax.persistence.CascadeType;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
@@ -35,7 +34,7 @@ public class Reservation {
   @JoinColumn(name = "user_id")
   private User user;
 
-  @OneToOne(cascade = {CascadeType.PERSIST, CascadeType.REMOVE})
+  @OneToOne
   @JoinColumn(name = "schedule_id")
   private Schedule schedule;
 

--- a/api/src/main/java/grooteogi/dto/ReservationRes.java
+++ b/api/src/main/java/grooteogi/dto/ReservationRes.java
@@ -13,6 +13,7 @@ public class ReservationRes {
   private String[] hashtags;
   private String date;
   private String startTime;
-  private String region;
+  private String endTime;
+  private String place;
 
 }

--- a/api/src/main/java/grooteogi/dto/ReservationRes.java
+++ b/api/src/main/java/grooteogi/dto/ReservationRes.java
@@ -10,7 +10,7 @@ public class ReservationRes {
   private int id;
   private String imgUrl;
   private String title;
-//  private String[] hashtags;
+  private String[] hashtags;
   private String date;
   private String startTime;
   private String region;

--- a/api/src/main/java/grooteogi/dto/ReservationRes.java
+++ b/api/src/main/java/grooteogi/dto/ReservationRes.java
@@ -1,0 +1,18 @@
+package grooteogi.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class ReservationRes {
+
+  private int id;
+  private String imgUrl;
+  private String title;
+//  private String[] hashtags;
+  private String date;
+  private String startTime;
+  private String region;
+
+}

--- a/api/src/main/java/grooteogi/repository/PostRepository.java
+++ b/api/src/main/java/grooteogi/repository/PostRepository.java
@@ -1,6 +1,7 @@
 package grooteogi.repository;
 
 import grooteogi.domain.Post;
+import grooteogi.domain.User;
 import io.lettuce.core.dynamic.annotation.Param;
 import java.util.List;
 import org.springframework.data.domain.Pageable;
@@ -21,4 +22,6 @@ public interface PostRepository extends JpaRepository<Post, Integer> {
       nativeQuery = true
   )
   List<Post> findAllByPage(Pageable pageable);
+
+  Boolean existsByUser(User user);
 }

--- a/api/src/main/java/grooteogi/repository/ReservationRepository.java
+++ b/api/src/main/java/grooteogi/repository/ReservationRepository.java
@@ -13,5 +13,5 @@ public interface ReservationRepository extends JpaRepository<Reservation, Intege
 
   @Query("select r, s, p from Post as p left outer join Schedule as s on p.id = s.post.id "
       + "inner join Reservation as r on s.id = r.schedule.id")
-  List<Object> findPostReservation();
+  List<Object[]> findPostReservation();
 }

--- a/api/src/main/java/grooteogi/repository/ReservationRepository.java
+++ b/api/src/main/java/grooteogi/repository/ReservationRepository.java
@@ -1,6 +1,7 @@
 package grooteogi.repository;
 
 import grooteogi.domain.Reservation;
+import io.lettuce.core.dynamic.annotation.Param;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -12,6 +13,6 @@ public interface ReservationRepository extends JpaRepository<Reservation, Intege
   List<Reservation> findByUserId(Integer userId);
 
   @Query("select r, s, p from Post as p left outer join Schedule as s on p.id = s.post.id "
-      + "inner join Reservation as r on s.id = r.schedule.id")
-  List<Object[]> findPostReservation();
+      + "inner join Reservation as r on s.id = r.schedule.id where p.user.id = :id")
+  List<Object[]> findPostReservation(@Param("id") int id);
 }

--- a/api/src/main/java/grooteogi/repository/ReservationRepository.java
+++ b/api/src/main/java/grooteogi/repository/ReservationRepository.java
@@ -4,9 +4,14 @@ import grooteogi.domain.Reservation;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 public interface ReservationRepository extends JpaRepository<Reservation, Integer> {
   Optional<Reservation> findByScheduleId(Integer scheduleId);
 
   List<Reservation> findByUserId(Integer userId);
+
+  @Query("select r, s, p from Post as p left outer join Schedule as s on p.id = s.post.id "
+      + "inner join Reservation as r on s.id = r.schedule.id")
+  List<Object> findPostReservation();
 }

--- a/api/src/main/java/grooteogi/service/ReservationService.java
+++ b/api/src/main/java/grooteogi/service/ReservationService.java
@@ -44,7 +44,8 @@ public class ReservationService {
       ReservationRes response = new ReservationRes();
       response.setId(reservation.getId());
       response.setDate(schedule.getDate());
-      response.setRegion(schedule.getRegion());
+      response.setEndTime(schedule.getEndTime());
+      response.setPlace(schedule.getPlace());
       response.setStartTime(schedule.getStartTime());
       response.setTitle(post.getTitle());
       response.setHashtags(getTags(post.getPostHashtags()));
@@ -107,6 +108,10 @@ public class ReservationService {
   }
 
   public void deleteReservation(Integer reservationId) {
-    reservationRepository.deleteById(reservationId);
+    Optional<Reservation> reservation = reservationRepository.findById(reservationId);
+    if (reservation.isEmpty()) {
+      throw new ApiException(ApiExceptionEnum.NOT_FOUND_EXCEPTION);
+    }
+    reservationRepository.delete(reservation.get());
   }
 }

--- a/api/src/main/java/grooteogi/service/ReservationService.java
+++ b/api/src/main/java/grooteogi/service/ReservationService.java
@@ -29,8 +29,8 @@ public class ReservationService {
   private final UserRepository userRepository;
   private final PostRepository postRepository;
 
-  public List<ReservationRes> getPostReservation() {
-     List<Object[]> reservations = reservationRepository.findPostReservation();
+  public List<ReservationRes> getPostReservation(int id) {
+    List<Object[]> reservations = reservationRepository.findPostReservation(id);
 
     if (reservations.size() == 0) {
       throw new ApiException(ApiExceptionEnum.RESERVATION_NOT_FOUND_EXCEPTION);

--- a/api/src/main/java/grooteogi/service/ReservationService.java
+++ b/api/src/main/java/grooteogi/service/ReservationService.java
@@ -1,6 +1,7 @@
 package grooteogi.service;
 
 import grooteogi.domain.Post;
+import grooteogi.domain.PostHashtag;
 import grooteogi.domain.Reservation;
 import grooteogi.domain.Schedule;
 import grooteogi.domain.User;
@@ -29,12 +30,7 @@ public class ReservationService {
   private final PostRepository postRepository;
 
   public List<ReservationRes> getPostReservation() {
-    /*
-    * [grooteogi.domain.Reservation@17743dc4,
-    * grooteogi.domain.Schedule@245c2d9c,
-    * grooteogi.domain.Post@4d1f340e]
-    * */
-    List<Object[]> reservations = reservationRepository.findPostReservation();
+     List<Object[]> reservations = reservationRepository.findPostReservation();
 
     if (reservations.size() == 0) {
       throw new ApiException(ApiExceptionEnum.RESERVATION_NOT_FOUND_EXCEPTION);
@@ -51,11 +47,20 @@ public class ReservationService {
       response.setRegion(schedule.getRegion());
       response.setStartTime(schedule.getStartTime());
       response.setTitle(post.getTitle());
-//      response.setHashtags();
+      response.setHashtags(getTags(post.getPostHashtags()));
       response.setImgUrl(post.getImageUrl());
       responseList.add(response);
     }
     return responseList;
+  }
+
+  private String[] getTags(List<PostHashtag> postHashtags) {
+    String[] tags = new String[postHashtags.size()];
+    postHashtags.forEach(tag -> {
+      int i = 0;
+      tags[i++] = tag.getHashTag().getTag();
+    });
+    return tags;
   }
 
   public List<Reservation> getUserReservation(Integer userId) {

--- a/api/src/main/java/grooteogi/service/ReservationService.java
+++ b/api/src/main/java/grooteogi/service/ReservationService.java
@@ -1,33 +1,61 @@
 package grooteogi.service;
 
+import grooteogi.domain.Post;
 import grooteogi.domain.Reservation;
+import grooteogi.domain.Schedule;
+import grooteogi.domain.User;
 import grooteogi.dto.ReservationDto;
+import grooteogi.dto.ReservationRes;
 import grooteogi.exception.ApiException;
 import grooteogi.exception.ApiExceptionEnum;
 import grooteogi.repository.PostRepository;
 import grooteogi.repository.ReservationRepository;
+import grooteogi.repository.ScheduleRepository;
 import grooteogi.repository.UserRepository;
 import java.sql.Timestamp;
 import java.time.LocalDateTime;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
-import org.springframework.beans.BeanUtils;
 import org.springframework.stereotype.Service;
 
 @Service
 @RequiredArgsConstructor
 public class ReservationService {
   private final ReservationRepository reservationRepository;
+  private final ScheduleRepository scheduleRepository;
   private final UserRepository userRepository;
+  private final PostRepository postRepository;
 
-  public List<Reservation> getPostReservation() {
-    List<Object> reservations = reservationRepository.findPostReservation();
+  public List<ReservationRes> getPostReservation() {
+    /*
+    * [grooteogi.domain.Reservation@17743dc4,
+    * grooteogi.domain.Schedule@245c2d9c,
+    * grooteogi.domain.Post@4d1f340e]
+    * */
+    List<Object[]> reservations = reservationRepository.findPostReservation();
 
-    if (reservations.isEmpty()) {
+    if (reservations.size() == 0) {
       throw new ApiException(ApiExceptionEnum.RESERVATION_NOT_FOUND_EXCEPTION);
     }
-    return null;
+
+    List<ReservationRes> responseList = new ArrayList<>();
+    for (Object[] arr : reservations) {
+      Reservation reservation = (Reservation) arr[0];
+      Schedule schedule = (Schedule) arr[1];
+      Post post = (Post) arr[2];
+      ReservationRes response = new ReservationRes();
+      response.setId(reservation.getId());
+      response.setDate(schedule.getDate());
+      response.setRegion(schedule.getRegion());
+      response.setStartTime(schedule.getStartTime());
+      response.setTitle(post.getTitle());
+//      response.setHashtags();
+      response.setImgUrl(post.getImageUrl());
+      responseList.add(response);
+    }
+    return responseList;
   }
 
   public List<Reservation> getUserReservation(Integer userId) {
@@ -46,19 +74,28 @@ public class ReservationService {
     return reservation.get();
   }
 
-  public Reservation createReservation(ReservationDto reservationDto) {
+  public Reservation createReservation(ReservationDto reservationDto, int userId) {
     Optional<Reservation> reservation = reservationRepository
         .findByScheduleId(reservationDto.getScheduleId());
     if (reservation.isPresent()) {
       throw new ApiException(ApiExceptionEnum.DUPLICATION_RESERVATION_EXCEPTION);
     }
 
-    if (reservation.get().getSchedule() == null) {
+    Optional<Schedule> schedule = scheduleRepository.findById(reservationDto.getScheduleId());
+    if (schedule.isEmpty()) {
       throw new ApiException(ApiExceptionEnum.SCHEDULE_NOT_FOUND_EXCEPTION);
     }
 
+    Optional<User> user = userRepository.findById(userId);
+    boolean isWriter = postRepository.existsByUser(user.get());
+    if (isWriter) {
+      throw new ApiException(ApiExceptionEnum.BAD_REQUEST_EXCEPTION);
+    }
+
     Reservation createdReservation = new Reservation();
-    BeanUtils.copyProperties(reservationDto, createdReservation);
+    createdReservation.setSchedule(schedule.get());
+    createdReservation.setUser(user.get());
+    createdReservation.setMessage(reservationDto.getMessage());
     createdReservation.setCreateDate(Timestamp.valueOf(LocalDateTime.now()));
 
     return reservationRepository.save(createdReservation);

--- a/api/src/main/java/grooteogi/service/ReservationService.java
+++ b/api/src/main/java/grooteogi/service/ReservationService.java
@@ -4,6 +4,7 @@ import grooteogi.domain.Reservation;
 import grooteogi.dto.ReservationDto;
 import grooteogi.exception.ApiException;
 import grooteogi.exception.ApiExceptionEnum;
+import grooteogi.repository.PostRepository;
 import grooteogi.repository.ReservationRepository;
 import grooteogi.repository.UserRepository;
 import java.sql.Timestamp;
@@ -20,8 +21,17 @@ public class ReservationService {
   private final ReservationRepository reservationRepository;
   private final UserRepository userRepository;
 
-  public List<Reservation> getAllReservation() {
-    List<Reservation> reservations = reservationRepository.findAll();
+  public List<Reservation> getPostReservation() {
+    List<Object> reservations = reservationRepository.findPostReservation();
+
+    if (reservations.isEmpty()) {
+      throw new ApiException(ApiExceptionEnum.RESERVATION_NOT_FOUND_EXCEPTION);
+    }
+    return null;
+  }
+
+  public List<Reservation> getUserReservation(Integer userId) {
+    List<Reservation> reservations = reservationRepository.findByUserId(userId);
     if (reservations.isEmpty()) {
       throw new ApiException(ApiExceptionEnum.RESERVATION_NOT_FOUND_EXCEPTION);
     }
@@ -57,13 +67,4 @@ public class ReservationService {
   public void deleteReservation(Integer reservationId) {
     reservationRepository.deleteById(reservationId);
   }
-
-  public List<Reservation> getUserReservation(Integer userId) {
-    List<Reservation> reservations = reservationRepository.findByUserId(userId);
-    if (reservations.isEmpty()) {
-      throw new ApiException(ApiExceptionEnum.RESERVATION_NOT_FOUND_EXCEPTION);
-    }
-    return reservations;
-  }
-
 }


### PR DESCRIPTION
## Related Issue
#78 reservation api 중 get method 수정
## Description
참가자/주최자에 따른 다른 url로 get 요청 처리
- 참가자 "reservation/apply"
- 주최자 "reservation/post" 
## Changes
ReservationController getPostReservation()
- 주최자의 예약 조회 시, 주최자 id를 param으로 받지 않고 session에서 찾는 로직으로 변경

ReservationController getUserReservation()
- 참가자의 예약 조회 시, 참가자 id를 param으로 받지 않고 session에서 찾는 로직으로 변경

ResevationRes DTO 생성
- 피그마에서 사용하는 데이터만을 담은 DTO 클래스 생성

ReservationService 내부 getTags()
- post의 해시태그 이름만 String[] 타입으로 반환하는 함수 정의

ReservationRepository findPostReservation(id)
- query 조건 추가
## Note
ReservationService createReservation()
- 함수 내부 로직 수정할 예정입니다. DB에 값은 잘 들어가요.