### PR TITLE
refactor: Change date and time type in schedule

### DIFF
--- a/api/src/docs/asciidoc/api.adoc
+++ b/api/src/docs/asciidoc/api.adoc
@@ -54,3 +54,48 @@ include::{snippets}/auth-withdrawal/http-request.adoc[]
 
 ==== Response
 include::{snippets}/auth-withdrawal/http-response.adoc[]
+
+== Reservation API
+
+=== Get Reservation
+
+==== Response
+include::{snippets}/get-reservation/http-response.adoc[]
+
+==== Response Fields
+include::{snippets}/get-reservation/response-fields.adoc[]
+
+=== Get Host User Reservation
+
+==== Response
+include::{snippets}/get-host-reservation/http-response.adoc[]
+
+==== Response Fields
+include::{snippets}/get-host-reservation/response-fields.adoc[]
+
+=== Get Participate User Reservation
+
+==== Response
+include::{snippets}/get-participate-reservation/http-response.adoc[]
+
+==== Response Fields
+include::{snippets}/get-participate-reservation/response-fields.adoc[]
+
+=== Create Reservation
+
+==== Request
+include::{snippets}/create-reservation/http-request.adoc[]
+
+==== Response
+include::{snippets}/create-reservation/http-response.adoc[]
+
+==== Response Fields
+include::{snippets}/create-reservation/response-fields.adoc[]
+
+=== Delete Reservation
+
+==== Request
+include::{snippets}/delete-reservation/http-request.adoc[]
+
+==== Response
+include::{snippets}/delete-reservation/http-response.adoc[]

--- a/api/src/main/java/grooteogi/controller/PostController.java
+++ b/api/src/main/java/grooteogi/controller/PostController.java
@@ -1,6 +1,5 @@
 package grooteogi.controller;
 
-import grooteogi.domain.Post;
 import grooteogi.dto.PostDto;
 import grooteogi.response.BasicResponse;
 import grooteogi.service.PostService;
@@ -27,12 +26,12 @@ public class PostController {
 
   @GetMapping
   public ResponseEntity<BasicResponse> search(
-      @RequestParam(name = "search", required = false) String search,
+      @RequestParam(name = "keyword", required = false) String keyword,
       @RequestParam(name = "page", defaultValue = "1") Integer page,
-      @RequestParam(name = "type", required = false) String type) {
+      @RequestParam(name = "sort", required = false) String sort) {
 
     List<PostDto.Response> posts =
-        postService.search(search, type, PageRequest.of(page - 1, 20));
+        postService.search(keyword, sort, PageRequest.of(page - 1, 20));
     return ResponseEntity.ok(BasicResponse.builder().data(posts).build());
   }
 
@@ -57,8 +56,8 @@ public class PostController {
 
   @DeleteMapping("/{postId}")
   public ResponseEntity<BasicResponse> deletePost(@PathVariable int postId) {
-    List<PostDto.Response> deletePost = this.postService.deletePost(postId);
+    postService.deletePost(postId);
     return ResponseEntity.ok(
-        BasicResponse.builder().count(deletePost.size()).data(deletePost).build());
+        BasicResponse.builder().message("delete post success").build());
   }
 }

--- a/api/src/main/java/grooteogi/controller/PostController.java
+++ b/api/src/main/java/grooteogi/controller/PostController.java
@@ -31,32 +31,33 @@ public class PostController {
       @RequestParam(name = "page", defaultValue = "1") Integer page,
       @RequestParam(name = "type", required = false) String type) {
 
-    List<Post> posts = postService.search(search, type, PageRequest.of(page - 1, 20));
+    List<PostDto.Response> posts =
+        postService.search(search, type, PageRequest.of(page - 1, 20));
     return ResponseEntity.ok(BasicResponse.builder().data(posts).build());
   }
 
   @GetMapping("/{postId}")
   public ResponseEntity<BasicResponse> getPost(@PathVariable int postId) {
-    Post post = postService.getPost(postId);
+    PostDto.Response post = postService.getPost(postId);
     return ResponseEntity.ok(BasicResponse.builder().data(post).build());
   }
 
   @PostMapping
   public ResponseEntity<BasicResponse> createPost(@RequestBody PostDto.Request request) {
-    Post createdPost = this.postService.createPost(request);
+    PostDto.Response createdPost = this.postService.createPost(request);
     return ResponseEntity.ok(BasicResponse.builder().data(createdPost).build());
   }
 
   @PutMapping("/{postId}")
   public ResponseEntity<BasicResponse> modifyPost(@RequestBody PostDto.Request request,
       @PathVariable int postId) {
-    Post modifiedPost = this.postService.modifyPost(request, postId);
+    PostDto.Response modifiedPost = this.postService.modifyPost(request, postId);
     return ResponseEntity.ok(BasicResponse.builder().data(modifiedPost).build());
   }
 
   @DeleteMapping("/{postId}")
   public ResponseEntity<BasicResponse> deletePost(@PathVariable int postId) {
-    List<Post> deletePost = this.postService.deletePost(postId);
+    List<PostDto.Response> deletePost = this.postService.deletePost(postId);
     return ResponseEntity.ok(
         BasicResponse.builder().count(deletePost.size()).data(deletePost).build());
   }

--- a/api/src/main/java/grooteogi/controller/ReservationController.java
+++ b/api/src/main/java/grooteogi/controller/ReservationController.java
@@ -1,6 +1,5 @@
 package grooteogi.controller;
 
-import grooteogi.domain.Reservation;
 import grooteogi.dto.ReservationDto;
 import grooteogi.response.BasicResponse;
 import grooteogi.service.ReservationService;
@@ -36,8 +35,8 @@ public class ReservationController {
 
   @GetMapping("/{reservationId}")
   public ResponseEntity<BasicResponse> getReservation(@PathVariable Integer reservationId) {
-    Reservation reservation = reservationService.getReservation(reservationId);
-    return ResponseEntity.ok(BasicResponse.builder().data(reservation).build());
+    ReservationDto.Response response = reservationService.getReservation(reservationId);
+    return ResponseEntity.ok(BasicResponse.builder().data(response).build());
   }
 
   @GetMapping("/apply")
@@ -56,7 +55,7 @@ public class ReservationController {
     Session session = (Session) SecurityContextHolder.getContext().getAuthentication()
         .getPrincipal();
 
-    Reservation createdReservation = reservationService.createReservation(request,
+    ReservationDto.Response createdReservation = reservationService.createReservation(request,
         session.getId());
     return ResponseEntity.ok(BasicResponse.builder().data(createdReservation).build());
   }

--- a/api/src/main/java/grooteogi/domain/Hashtag.java
+++ b/api/src/main/java/grooteogi/domain/Hashtag.java
@@ -9,13 +9,19 @@ import javax.persistence.Enumerated;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.Setter;
 import org.hibernate.annotations.CreationTimestamp;
 
 @Getter
 @Setter
 @Entity
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
 public class Hashtag {
 
   @Id

--- a/api/src/main/java/grooteogi/domain/Heart.java
+++ b/api/src/main/java/grooteogi/domain/Heart.java
@@ -7,12 +7,18 @@ import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.Setter;
 
 @Getter
 @Setter
 @Entity
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
 public class Heart {
 
   @Id

--- a/api/src/main/java/grooteogi/domain/Post.java
+++ b/api/src/main/java/grooteogi/domain/Post.java
@@ -20,7 +20,10 @@ import javax.persistence.JoinColumn;
 import javax.persistence.Lob;
 import javax.persistence.ManyToOne;
 import javax.persistence.OneToMany;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.Setter;
 import org.hibernate.annotations.CreationTimestamp;
 import org.hibernate.annotations.UpdateTimestamp;
@@ -28,6 +31,9 @@ import org.hibernate.annotations.UpdateTimestamp;
 @Getter
 @Setter
 @Entity
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
 public class Post {
 
   @Id

--- a/api/src/main/java/grooteogi/domain/PostHashtag.java
+++ b/api/src/main/java/grooteogi/domain/PostHashtag.java
@@ -9,13 +9,19 @@ import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.Setter;
 import org.hibernate.annotations.CreationTimestamp;
 
 @Getter
 @Setter
 @Entity
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
 public class PostHashtag {
 
   @Id

--- a/api/src/main/java/grooteogi/domain/Reservation.java
+++ b/api/src/main/java/grooteogi/domain/Reservation.java
@@ -10,13 +10,19 @@ import javax.persistence.Id;
 import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
 import javax.persistence.OneToOne;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.Setter;
 import org.hibernate.annotations.CreationTimestamp;
 
 @Getter
 @Setter
 @Entity
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
 public class Reservation {
 
   @Id

--- a/api/src/main/java/grooteogi/domain/Review.java
+++ b/api/src/main/java/grooteogi/domain/Review.java
@@ -11,7 +11,10 @@ import javax.persistence.Id;
 import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
 import javax.persistence.OneToOne;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.Setter;
 import org.hibernate.annotations.CreationTimestamp;
 import org.hibernate.annotations.UpdateTimestamp;
@@ -19,6 +22,9 @@ import org.hibernate.annotations.UpdateTimestamp;
 @Getter
 @Setter
 @Entity
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
 public class Review {
 
   @Id

--- a/api/src/main/java/grooteogi/domain/Schedule.java
+++ b/api/src/main/java/grooteogi/domain/Schedule.java
@@ -1,6 +1,8 @@
 package grooteogi.domain;
 
 import com.fasterxml.jackson.annotation.JsonBackReference;
+import java.time.LocalDate;
+import java.time.LocalTime;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
@@ -20,13 +22,13 @@ public class Schedule {
   private int id;
 
   @Column(nullable = false, length = 10)
-  private String date;
+  private LocalDate date;
 
   @Column(nullable = false, length = 10)
-  private String startTime;
+  private LocalTime startTime;
 
   @Column(nullable = false, length = 10)
-  private String endTime;
+  private LocalTime endTime;
 
   @Column(nullable = false, length = 10)
   private String region;

--- a/api/src/main/java/grooteogi/domain/Schedule.java
+++ b/api/src/main/java/grooteogi/domain/Schedule.java
@@ -10,12 +10,18 @@ import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.Setter;
 
 @Getter
 @Setter
 @Entity
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
 public class Schedule {
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/api/src/main/java/grooteogi/domain/Schedule.java
+++ b/api/src/main/java/grooteogi/domain/Schedule.java
@@ -1,8 +1,8 @@
 package grooteogi.domain;
 
 import com.fasterxml.jackson.annotation.JsonBackReference;
-import java.time.LocalDate;
-import java.time.LocalTime;
+import java.sql.Date;
+import java.sql.Time;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
@@ -22,13 +22,13 @@ public class Schedule {
   private int id;
 
   @Column(nullable = false, length = 10)
-  private LocalDate date;
+  private Date date;
 
   @Column(nullable = false, length = 10)
-  private LocalTime startTime;
+  private Time startTime;
 
   @Column(nullable = false, length = 10)
-  private LocalTime endTime;
+  private Time endTime;
 
   @Column(nullable = false, length = 10)
   private String region;

--- a/api/src/main/java/grooteogi/domain/User.java
+++ b/api/src/main/java/grooteogi/domain/User.java
@@ -16,7 +16,10 @@ import javax.persistence.Id;
 import javax.persistence.JoinColumn;
 import javax.persistence.OneToMany;
 import javax.persistence.OneToOne;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.Setter;
 import org.hibernate.annotations.CreationTimestamp;
 import org.hibernate.annotations.UpdateTimestamp;
@@ -24,6 +27,9 @@ import org.hibernate.annotations.UpdateTimestamp;
 @Getter
 @Setter
 @Entity
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
 public class User {
 
   @Id

--- a/api/src/main/java/grooteogi/domain/UserHashtag.java
+++ b/api/src/main/java/grooteogi/domain/UserHashtag.java
@@ -9,13 +9,19 @@ import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.Setter;
 import org.hibernate.annotations.CreationTimestamp;
 
 @Getter
 @Setter
 @Entity
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
 public class UserHashtag {
 
   @Id

--- a/api/src/main/java/grooteogi/domain/UserInfo.java
+++ b/api/src/main/java/grooteogi/domain/UserInfo.java
@@ -6,7 +6,10 @@ import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.Setter;
 import org.hibernate.annotations.CreationTimestamp;
 import org.hibernate.annotations.UpdateTimestamp;
@@ -14,6 +17,9 @@ import org.hibernate.annotations.UpdateTimestamp;
 @Getter
 @Setter
 @Entity
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
 public class UserInfo {
 
   @Id

--- a/api/src/main/java/grooteogi/dto/PostDto.java
+++ b/api/src/main/java/grooteogi/dto/PostDto.java
@@ -1,6 +1,7 @@
 package grooteogi.dto;
 
 import grooteogi.enums.CreditType;
+import java.util.List;
 import javax.validation.constraints.NotBlank;
 import lombok.Builder;
 import lombok.Data;
@@ -27,7 +28,26 @@ public class PostDto {
 
     private String[] hashtags;
 
-    private Object[] schedules;
+    private List<ScheduleDto.Request> schedules;
   }
 
+  @Data
+  @Builder
+  public static class Response {
+
+    private String title;
+
+    private String content;
+
+    private String imageUrl;
+
+    private int views;
+
+    private CreditType credit;
+
+    private String nickname;
+
+    private String date;
+
+  }
 }

--- a/api/src/main/java/grooteogi/dto/ReservationDto.java
+++ b/api/src/main/java/grooteogi/dto/ReservationDto.java
@@ -1,5 +1,7 @@
 package grooteogi.dto;
 
+import java.time.LocalDate;
+import java.time.LocalTime;
 import java.util.List;
 import javax.validation.constraints.NotNull;
 import lombok.Builder;
@@ -22,9 +24,9 @@ public class ReservationDto {
     private String imgUrl;
     private String title;
     private List<String> hashtags;
-    private String date;
-    private String startTime;
-    private String endTime;
+    private LocalDate date;
+    private LocalTime startTime;
+    private LocalTime endTime;
     private String place;
   }
 }

--- a/api/src/main/java/grooteogi/dto/ReservationDto.java
+++ b/api/src/main/java/grooteogi/dto/ReservationDto.java
@@ -1,6 +1,5 @@
 package grooteogi.dto;
 
-import java.time.LocalDate;
 import java.time.LocalTime;
 import java.util.List;
 import javax.validation.constraints.NotNull;
@@ -24,9 +23,9 @@ public class ReservationDto {
     private String imgUrl;
     private String title;
     private List<String> hashtags;
-    private LocalDate date;
-    private LocalTime startTime;
-    private LocalTime endTime;
+    private String date;
+    private String startTime;
+    private String endTime;
     private String place;
   }
 }

--- a/api/src/main/java/grooteogi/dto/ReservationDto.java
+++ b/api/src/main/java/grooteogi/dto/ReservationDto.java
@@ -1,6 +1,5 @@
 package grooteogi.dto;
 
-import java.time.LocalTime;
 import java.util.List;
 import javax.validation.constraints.NotNull;
 import lombok.Builder;
@@ -20,7 +19,7 @@ public class ReservationDto {
   @Builder
   public static class Response {
     private int reservationId;
-    private String imgUrl;
+    private String imageUrl;
     private String title;
     private List<String> hashtags;
     private String date;

--- a/api/src/main/java/grooteogi/dto/ScheduleDto.java
+++ b/api/src/main/java/grooteogi/dto/ScheduleDto.java
@@ -1,0 +1,23 @@
+package grooteogi.dto;
+
+import lombok.Builder;
+import lombok.Data;
+
+public class ScheduleDto {
+
+  @Data
+  @Builder
+  public static class Request {
+
+    private String date;
+
+    private String startTime;
+
+    private String endTime;
+
+    private String region;
+
+    private String place;
+
+  }
+}

--- a/api/src/main/java/grooteogi/mapper/DateMapper.java
+++ b/api/src/main/java/grooteogi/mapper/DateMapper.java
@@ -1,0 +1,37 @@
+package grooteogi.mapper;
+
+import java.sql.Date;
+import java.sql.Time;
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+
+public class DateMapper {
+
+  public String asStringDate(Date date) {
+    return date != null ? new SimpleDateFormat("yyyy-MM-dd")
+        .format(date) : null;
+  }
+
+  public Date asDate(String date) {
+    try {
+      return date != null ? (Date) new SimpleDateFormat("yyyy-MM-dd")
+          .parse(date) : null;
+    } catch (ParseException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  public String asStringTime(Time time) {
+    return time != null ? new SimpleDateFormat("HH:mm:ss")
+        .format(time) : null;
+  }
+
+  public Time adTime(String time) {
+    try {
+      return time != null ? (Time) new SimpleDateFormat("HH:mm:ss")
+          .parse(time) : null;
+    } catch (ParseException e) {
+      throw new RuntimeException(e);
+    }
+  }
+}

--- a/api/src/main/java/grooteogi/mapper/PostMapper.java
+++ b/api/src/main/java/grooteogi/mapper/PostMapper.java
@@ -1,0 +1,34 @@
+package grooteogi.mapper;
+
+import grooteogi.domain.Post;
+import grooteogi.domain.PostHashtag;
+import grooteogi.domain.Schedule;
+import grooteogi.domain.User;
+import grooteogi.dto.PostDto;
+import java.util.List;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.Mappings;
+import org.mapstruct.factory.Mappers;
+
+@Mapper(componentModel = "spring", uses = DateMapper.class)
+public interface PostMapper extends BasicMapper<PostDto, Post> {
+
+  PostMapper INSTANCE = Mappers.getMapper(PostMapper.class);
+
+  Post toEntity(PostDto.Request dto, User user,
+      List<PostHashtag> postHashtags, List<Schedule> schedules);
+
+  PostDto.Response toResponseDto(Post post);
+
+  @Mappings({
+      @Mapping(source = "dto.title", target = "title"),
+      @Mapping(source = "dto.content", target = "content"),
+      @Mapping(source = "dto.imageUrl", target = "imageUrl"),
+      @Mapping(source = "dto.credit", target = "credit"),
+      @Mapping(source = "post.schedules", target = "schedules"),
+      @Mapping(source = "post.postHashtags", target = "postHashtags")
+  })
+  Post toModify(Post post, PostDto.Request dto);
+
+}

--- a/api/src/main/java/grooteogi/mapper/ReservationMapper.java
+++ b/api/src/main/java/grooteogi/mapper/ReservationMapper.java
@@ -20,5 +20,9 @@ public interface ReservationMapper extends BasicMapper<ReservationDto, Reservati
   @Mapping(source = "schedule.post.user", target = "hostUser")
   Reservation toEntity(ReservationDto.Request dto, User user, Schedule schedule);
 
+  @Mapping(target = "date", dateFormat = "yyyy-MM-dd")
+  @Mapping(target = "startTime", dateFormat = "HH:mm")
+  @Mapping(target = "endTime", dateFormat = "HH:mm")
+  @Mapping(source = "post.imageUrl", target = "imageUrl")
   ReservationDto.Response toResponseDto(Reservation reservation, Post post, Schedule schedule);
 }

--- a/api/src/main/java/grooteogi/mapper/ReservationMapper.java
+++ b/api/src/main/java/grooteogi/mapper/ReservationMapper.java
@@ -15,19 +15,19 @@ public interface ReservationMapper extends BasicMapper<ReservationDto, Reservati
 
   ReservationMapper INSTANCE = Mappers.getMapper(ReservationMapper.class);
 
- @Mappings({
-     @Mapping(target = "id", ignore = true),
-     @Mapping(source = "schedule", target = "schedule"),
-     @Mapping(source = "user", target = "participateUser"),
-     @Mapping(source = "schedule.post.user", target = "hostUser")
- })
+  @Mappings({
+      @Mapping(target = "id", ignore = true),
+      @Mapping(source = "schedule", target = "schedule"),
+      @Mapping(source = "user", target = "participateUser"),
+      @Mapping(source = "schedule.post.user", target = "hostUser")
+  })
   Reservation toEntity(ReservationDto.Request dto, User user, Schedule schedule);
 
-@Mappings({
-    @Mapping(target = "date", dateFormat = "yyyy-MM-dd"),
-    @Mapping(target = "startTime", dateFormat = "HH:mm:ss"),
-    @Mapping(target = "endTime", dateFormat = "HH:mm:ss"),
-    @Mapping(source = "post.imageUrl", target = "imageUrl")
-})
+  @Mappings({
+      @Mapping(target = "date", dateFormat = "yyyy-MM-dd"),
+      @Mapping(target = "startTime", dateFormat = "HH:mm:ss"),
+      @Mapping(target = "endTime", dateFormat = "HH:mm:ss"),
+      @Mapping(source = "post.imageUrl", target = "imageUrl")
+  })
   ReservationDto.Response toResponseDto(Reservation reservation, Post post, Schedule schedule);
 }

--- a/api/src/main/java/grooteogi/mapper/ReservationMapper.java
+++ b/api/src/main/java/grooteogi/mapper/ReservationMapper.java
@@ -7,6 +7,7 @@ import grooteogi.domain.User;
 import grooteogi.dto.ReservationDto;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
+import org.mapstruct.Mappings;
 import org.mapstruct.factory.Mappers;
 
 @Mapper(componentModel = "spring")
@@ -14,15 +15,19 @@ public interface ReservationMapper extends BasicMapper<ReservationDto, Reservati
 
   ReservationMapper INSTANCE = Mappers.getMapper(ReservationMapper.class);
 
-  @Mapping(target = "id", ignore = true)
-  @Mapping(source = "schedule", target = "schedule")
-  @Mapping(source = "user", target = "participateUser")
-  @Mapping(source = "schedule.post.user", target = "hostUser")
+ @Mappings({
+     @Mapping(target = "id", ignore = true),
+     @Mapping(source = "schedule", target = "schedule"),
+     @Mapping(source = "user", target = "participateUser"),
+     @Mapping(source = "schedule.post.user", target = "hostUser")
+ })
   Reservation toEntity(ReservationDto.Request dto, User user, Schedule schedule);
 
-  @Mapping(target = "date", dateFormat = "yyyy-MM-dd")
-  @Mapping(target = "startTime", dateFormat = "HH:mm")
-  @Mapping(target = "endTime", dateFormat = "HH:mm")
-  @Mapping(source = "post.imageUrl", target = "imageUrl")
+@Mappings({
+    @Mapping(target = "date", dateFormat = "yyyy-MM-dd"),
+    @Mapping(target = "startTime", dateFormat = "HH:mm:ss"),
+    @Mapping(target = "endTime", dateFormat = "HH:mm:ss"),
+    @Mapping(source = "post.imageUrl", target = "imageUrl")
+})
   ReservationDto.Response toResponseDto(Reservation reservation, Post post, Schedule schedule);
 }

--- a/api/src/main/java/grooteogi/mapper/ScheduleMapper.java
+++ b/api/src/main/java/grooteogi/mapper/ScheduleMapper.java
@@ -1,0 +1,22 @@
+package grooteogi.mapper;
+
+import grooteogi.domain.Schedule;
+import grooteogi.dto.ScheduleDto;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.Mappings;
+import org.mapstruct.factory.Mappers;
+
+@Mapper(componentModel = "spring", uses = DateMapper.class)
+public interface ScheduleMapper extends BasicMapper<ScheduleDto, Schedule>  {
+
+  ScheduleMapper INSTANCE = Mappers.getMapper(ScheduleMapper.class);
+
+  @Mappings({
+      @Mapping(target = "date", source = "dto.date", dateFormat = "yyyy-MM-dd"),
+      @Mapping(target = "startTime", source = "dto.startTime", dateFormat = "HH:mm:ss"),
+      @Mapping(target = "endTime", source = "dto.endTime", dateFormat = "HH:mm:ss")
+  })
+  Schedule toEntity(ScheduleDto.Request dto);
+
+}

--- a/api/src/main/java/grooteogi/service/PostService.java
+++ b/api/src/main/java/grooteogi/service/PostService.java
@@ -70,8 +70,8 @@ public class PostService {
       schedules.add(createdSchedule);
     });
 
-    Post created = this.postRepository
-        .save(PostMapper.INSTANCE.toEntity(request, user.get(), postHashtags, schedules));
+    Post created = PostMapper.INSTANCE.toEntity(request, user.get(), postHashtags, schedules);
+    postRepository.save(PostMapper.INSTANCE.toEntity(request, user.get(), postHashtags, schedules));
     PostDto.Response response = PostMapper.INSTANCE.toResponseDto(created);
 
     return response;
@@ -107,12 +107,13 @@ public class PostService {
       post.get().getPostHashtags().add(modifiedPostHashtag);
     });
 
-    Post modifiedPost = postRepository.save(PostMapper.INSTANCE.toModify(post.get(), request));
+    Post modifiedPost = PostMapper.INSTANCE.toModify(post.get(), request);
+    postRepository.save(modifiedPost);
     PostDto.Response response = PostMapper.INSTANCE.toResponseDto(modifiedPost);
     return response;
   }
 
-  public List<PostDto.Response> deletePost(int postId) {
+  public void deletePost(int postId) {
     Optional<Post> post = this.postRepository.findById(postId);
 
     if (post.isEmpty()) {
@@ -127,35 +128,30 @@ public class PostService {
     });
 
     this.postRepository.delete(post.get());
-
-    List<PostDto.Response> responses = new ArrayList<>();
-    this.postRepository.findAll().forEach(result -> responses
-        .add(PostMapper.INSTANCE.toResponseDto(result)));
-    return responses;
   }
 
-  public List<PostDto.Response> search(String search, String type,
+  public List<PostDto.Response> search(String keyword, String sort,
       Pageable page) {
     final List<PostDto.Response> posts;
-    if (search == null) {
-      posts = searchAllPosts(page, type);
+    if (keyword == null) {
+      posts = searchAllPosts(page, sort);
     } else {
-      posts = searchPosts(search, page, type);
+      posts = searchPosts(keyword, page, sort);
     }
     return posts;
   }
 
 
-  public List<PostDto.Response> searchAllPosts(Pageable page, String type) {
+  public List<PostDto.Response> searchAllPosts(Pageable page, String sort) {
     List<PostDto.Response> responses = new ArrayList<>();
     this.postRepository.findAllByPage(page).forEach(result -> responses
         .add(PostMapper.INSTANCE.toResponseDto(result)));
     return responses;
   }
 
-  private List<PostDto.Response> searchPosts(String search, Pageable page, String type) {
+  private List<PostDto.Response> searchPosts(String keyword, Pageable page, String sort) {
     List<PostDto.Response> responses = new ArrayList<>();
-    this.postRepository.findBySearch(search, search, page).forEach(result -> responses
+    this.postRepository.findBySearch(keyword, keyword, page).forEach(result -> responses
         .add(PostMapper.INSTANCE.toResponseDto(result)));
     return responses;
   }

--- a/api/src/main/java/grooteogi/service/PostService.java
+++ b/api/src/main/java/grooteogi/service/PostService.java
@@ -13,8 +13,8 @@ import grooteogi.repository.HashtagRepository;
 import grooteogi.repository.PostHashtagRepository;
 import grooteogi.repository.PostRepository;
 import grooteogi.repository.UserRepository;
-import java.time.LocalDate;
-import java.time.LocalTime;
+import java.sql.Date;
+import java.sql.Time;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
@@ -77,11 +77,11 @@ public class PostService {
     Arrays.stream(request.getSchedules()).forEach(schedule -> {
       Map<String, Object> map = mapper.convertValue(schedule, Map.class);
       Schedule createdSchedule = new Schedule();
-      createdSchedule.setDate((LocalDate) map.get("date"));
+      createdSchedule.setDate((Date) map.get("date"));
       createdSchedule.setRegion((String) map.get("region"));
       createdSchedule.setPlace((String) map.get("place"));
-      createdSchedule.setStartTime((LocalTime) map.get("startTime"));
-      createdSchedule.setEndTime((LocalTime) map.get("endTime"));
+      createdSchedule.setStartTime((Time) map.get("startTime"));
+      createdSchedule.setEndTime((Time) map.get("endTime"));
       createdSchedule.setPost(createdPost);
 
       createdPost.getSchedules().add(createdSchedule);

--- a/api/src/main/java/grooteogi/service/PostService.java
+++ b/api/src/main/java/grooteogi/service/PostService.java
@@ -13,6 +13,8 @@ import grooteogi.repository.HashtagRepository;
 import grooteogi.repository.PostHashtagRepository;
 import grooteogi.repository.PostRepository;
 import grooteogi.repository.UserRepository;
+import java.time.LocalDate;
+import java.time.LocalTime;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
@@ -75,11 +77,11 @@ public class PostService {
     Arrays.stream(request.getSchedules()).forEach(schedule -> {
       Map<String, Object> map = mapper.convertValue(schedule, Map.class);
       Schedule createdSchedule = new Schedule();
-      createdSchedule.setDate((String) map.get("date"));
+      createdSchedule.setDate((LocalDate) map.get("date"));
       createdSchedule.setRegion((String) map.get("region"));
       createdSchedule.setPlace((String) map.get("place"));
-      createdSchedule.setStartTime((String) map.get("startTime"));
-      createdSchedule.setEndTime((String) map.get("endTime"));
+      createdSchedule.setStartTime((LocalTime) map.get("startTime"));
+      createdSchedule.setEndTime((LocalTime) map.get("endTime"));
       createdSchedule.setPost(createdPost);
 
       createdPost.getSchedules().add(createdSchedule);

--- a/api/src/test/java/grooteogi/ApiDocumentUtils.java
+++ b/api/src/test/java/grooteogi/ApiDocumentUtils.java
@@ -37,11 +37,13 @@ public interface ApiDocumentUtils {
         .place("명지대")
         .build();
   }
+
   static List<Schedule> getSchedules() {
     List<Schedule> schedules = new ArrayList<>();
     schedules.add(getSchedule());
     return schedules;
   }
+
   static List<PostHashtag> getPostHashtags() {
     List<PostHashtag> tags = new ArrayList<>();
     PostHashtag tag = PostHashtag.builder()
@@ -50,6 +52,7 @@ public interface ApiDocumentUtils {
     tags.add(tag);
     return tags;
   }
+
   static Post getPost() {
     return Post.builder()
         .content("내용이다.")

--- a/api/src/test/java/grooteogi/ApiDocumentUtils.java
+++ b/api/src/test/java/grooteogi/ApiDocumentUtils.java
@@ -9,6 +9,7 @@ import grooteogi.domain.Hashtag;
 import grooteogi.domain.Post;
 import grooteogi.domain.PostHashtag;
 import grooteogi.domain.Schedule;
+import grooteogi.dto.ScheduleDto;
 import grooteogi.enums.CreditType;
 import java.sql.Date;
 import java.sql.Time;
@@ -62,5 +63,25 @@ public interface ApiDocumentUtils {
         .postHashtags(getPostHashtags())
         .schedules(getSchedules())
         .build();
+  }
+
+  static String[] getPostHashtagStrings() {
+    return new String[] {"해시태그", "문자열"};
+  }
+
+  static ScheduleDto.Request getScheduleReq() {
+    return ScheduleDto.Request.builder()
+        .date("2022-05-07")
+        .startTime("11:00:00")
+        .endTime("12:00:00")
+        .region("서대문구")
+        .place("명지대")
+        .build();
+  }
+
+  static List<ScheduleDto.Request> getScheduleReqs() {
+    List<ScheduleDto.Request> schedules = new ArrayList<>();
+    schedules.add(getScheduleReq());
+    return schedules;
   }
 }

--- a/api/src/test/java/grooteogi/ApiDocumentUtils.java
+++ b/api/src/test/java/grooteogi/ApiDocumentUtils.java
@@ -5,6 +5,15 @@ import static org.springframework.restdocs.operation.preprocess.Preprocessors.pr
 import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessResponse;
 import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
 
+import grooteogi.domain.Hashtag;
+import grooteogi.domain.Post;
+import grooteogi.domain.PostHashtag;
+import grooteogi.domain.Schedule;
+import grooteogi.enums.CreditType;
+import java.sql.Date;
+import java.sql.Time;
+import java.util.ArrayList;
+import java.util.List;
 import org.springframework.restdocs.operation.preprocess.OperationRequestPreprocessor;
 import org.springframework.restdocs.operation.preprocess.OperationResponsePreprocessor;
 
@@ -17,5 +26,38 @@ public interface ApiDocumentUtils {
 
   static OperationResponsePreprocessor getDocumentResponse() {
     return preprocessResponse(prettyPrint());
+  }
+
+  static Schedule getSchedule() {
+    return Schedule.builder()
+        .date(Date.valueOf("2022-05-07"))
+        .startTime(Time.valueOf("11:00:00"))
+        .endTime(Time.valueOf("12:00:00"))
+        .region("서대문구")
+        .place("명지대")
+        .build();
+  }
+  static List<Schedule> getSchedules() {
+    List<Schedule> schedules = new ArrayList<>();
+    schedules.add(getSchedule());
+    return schedules;
+  }
+  static List<PostHashtag> getPostHashtags() {
+    List<PostHashtag> tags = new ArrayList<>();
+    PostHashtag tag = PostHashtag.builder()
+        .hashTag(Hashtag.builder().tag("해시태그").build())
+        .build();
+    tags.add(tag);
+    return tags;
+  }
+  static Post getPost() {
+    return Post.builder()
+        .content("내용이다.")
+        .title("제목이다")
+        .credit(CreditType.DIRECT)
+        .imageUrl("이미지 주소다")
+        .postHashtags(getPostHashtags())
+        .schedules(getSchedules())
+        .build();
   }
 }

--- a/api/src/test/java/grooteogi/PostDocumentationTests.java
+++ b/api/src/test/java/grooteogi/PostDocumentationTests.java
@@ -1,0 +1,217 @@
+package grooteogi;
+
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.documentationConfiguration;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import grooteogi.config.UserInterceptor;
+import grooteogi.controller.PostController;
+import grooteogi.domain.Post;
+import grooteogi.domain.User;
+import grooteogi.dto.PostDto;
+import grooteogi.enums.CreditType;
+import grooteogi.mapper.PostMapper;
+import grooteogi.service.PostService;
+import grooteogi.utils.JwtProvider;
+import grooteogi.utils.Session;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.MediaType;
+import org.springframework.restdocs.RestDocumentationContextProvider;
+import org.springframework.restdocs.RestDocumentationExtension;
+import org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+
+@ExtendWith({RestDocumentationExtension.class, SpringExtension.class})
+@WebMvcTest(PostController.class)
+public class PostDocumentationTests {
+  @Autowired
+  private MockMvc mockMvc;
+  @MockBean
+  private PostService postService;
+  @MockBean
+  private UserInterceptor userInterceptor;
+  @MockBean
+  private JwtProvider jwtProvider;
+  @MockBean
+  private PasswordEncoder passwordEncoder;
+  @Autowired
+  private ObjectMapper objectMapper;
+  @MockBean
+  private Session session;
+  @MockBean
+  private Authentication authentication;
+  @MockBean
+  private SecurityContext securityContext;
+
+  @BeforeEach
+  void setUp(WebApplicationContext webApplicationContext,
+      RestDocumentationContextProvider restDocumentation) {
+    mockMvc = MockMvcBuilders.webAppContextSetup(webApplicationContext).apply(
+        documentationConfiguration(restDocumentation).operationPreprocessors()
+            .withRequestDefaults(prettyPrint()).withResponseDefaults(prettyPrint())).build();
+
+  }
+
+  @Test
+  @DisplayName("포스트 생성")
+  public void createPost() throws Exception {
+    // given
+    PostDto.Request request = postReq();
+    PostDto.Response response = postRes();
+
+    given(postService.createPost(eq(request))).willReturn(response);
+
+    String json = objectMapper.writeValueAsString(request);
+
+    // when
+    ResultActions resultActions = mockMvc.perform(
+        RestDocumentationRequestBuilders.post("/post").characterEncoding("utf-8")
+            .content(json)
+            .contentType(MediaType.APPLICATION_JSON)
+            .accept(MediaType.APPLICATION_JSON)
+    );
+
+    // then
+    resultActions.andExpect(status().isOk())
+        .andDo(print());
+
+  }
+
+  private PostDto.Response postRes() {
+    PostDto.Response response = PostMapper.INSTANCE.toResponseDto(ApiDocumentUtils.getPost());
+    return response;
+  }
+
+  @Test
+  @DisplayName("포스트 삭제")
+  public void deletePost() throws Exception {
+    // given
+    int postId = anyInt();
+
+    //when
+    ResultActions resultActions = mockMvc.perform(
+        RestDocumentationRequestBuilders
+            .delete("/post/{postId}", postId)
+            .characterEncoding("utf-8")
+            .accept(MediaType.APPLICATION_JSON)
+    );
+
+    //then
+    resultActions.andExpect(status().isOk())
+        .andDo(print());
+
+    verify(postService).deletePost(postId);
+  }
+
+  @Test
+  @DisplayName("포스트 수정")
+  public void modifyPost() throws Exception {
+    //given
+    int postId = anyInt();
+    PostDto.Request request = postReq();
+    PostDto.Response response = postRes();
+
+    given(postService.modifyPost(eq(request), postId)).willReturn(response);
+
+    String json = objectMapper.writeValueAsString(request);
+
+    // when
+    ResultActions resultActions = mockMvc.perform(
+        RestDocumentationRequestBuilders.put("/post/{postId}", postId).characterEncoding("utf-8")
+            .content(json)
+            .contentType(MediaType.APPLICATION_JSON)
+            .accept(MediaType.APPLICATION_JSON)
+    );
+
+    // then
+    resultActions.andExpect(status().isOk())
+        .andDo(print());
+  }
+
+  @Test
+  @DisplayName("포스트 조회")
+  public void getPost() throws Exception {
+    // given
+    PostDto.Response response = postRes();
+    int postId = anyInt();
+
+    // when
+    given(postService.getPost(postId)).willReturn(response);
+
+    // then
+    ResultActions result = mockMvc.perform(
+        RestDocumentationRequestBuilders
+            .get("/post/{postId}", postId)
+            .characterEncoding("utf-8")
+            .accept(MediaType.APPLICATION_JSON));
+    result.andExpect(status().isOk())
+        .andDo(print());
+  }
+
+  @Test
+  @DisplayName("포스트 검색")
+  public void search() throws Exception {
+    // given
+    String search = anyString();
+    String type = anyString();
+    Pageable page = PageRequest.of(0, 20);
+
+    PostDto.Response post = postRes();
+    List<PostDto.Response> response = new ArrayList<>();
+    response.add(post);
+
+    // when
+    given(postService.search(search, type, eq(page))).willReturn(response);
+
+    // then
+    ResultActions result = mockMvc.perform(
+        RestDocumentationRequestBuilders
+            .get("/post?search={search}&page={page}&type={type}", search, 1, type)
+            .characterEncoding("utf-8")
+            .accept(MediaType.APPLICATION_JSON));
+    result.andExpect(status().isOk())
+        .andDo(print());
+  }
+
+  private Post postEntity() {
+    Post post =  ApiDocumentUtils.getPost();
+    post.setUser(User.builder().build());
+    return post;
+  }
+
+  private PostDto.Request postReq() {
+    return PostDto.Request.builder()
+        .userId(1)
+        .content("이건 내용")
+        .credit(CreditType.DIRECT)
+        .title("이건 제목")
+        .hashtags(ApiDocumentUtils.getPostHashtagStrings())
+        .imageUrl("이미지 주소")
+        .schedules(ApiDocumentUtils.getScheduleReqs())
+        .build();
+  }
+}

--- a/api/src/test/java/grooteogi/ReservationDocumentationTests.java
+++ b/api/src/test/java/grooteogi/ReservationDocumentationTests.java
@@ -1,30 +1,39 @@
 package grooteogi;
 
+import static grooteogi.ApiDocumentUtils.getDocumentRequest;
+import static grooteogi.ApiDocumentUtils.getDocumentResponse;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.documentationConfiguration;
 import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.requestFields;
+import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import grooteogi.config.UserInterceptor;
 import grooteogi.controller.ReservationController;
+import grooteogi.domain.Hashtag;
 import grooteogi.domain.Post;
+import grooteogi.domain.PostHashtag;
 import grooteogi.domain.Reservation;
 import grooteogi.domain.Schedule;
 import grooteogi.domain.User;
 import grooteogi.dto.ReservationDto;
 import grooteogi.enums.CreditType;
 import grooteogi.enums.LoginType;
+import grooteogi.mapper.ReservationMapper;
 import grooteogi.service.ReservationService;
 import grooteogi.utils.JwtProvider;
 import grooteogi.utils.Session;
-import java.time.LocalDate;
-import java.time.LocalTime;
+import java.sql.Date;
+import java.sql.Time;
 import java.util.ArrayList;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
@@ -38,6 +47,7 @@ import org.springframework.http.MediaType;
 import org.springframework.restdocs.RestDocumentationContextProvider;
 import org.springframework.restdocs.RestDocumentationExtension;
 import org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders;
+import org.springframework.restdocs.payload.JsonFieldType;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContext;
 import org.springframework.security.core.context.SecurityContextHolder;
@@ -72,12 +82,13 @@ public class ReservationDocumentationTests {
   private SecurityContext securityContext;
 
   User hostUser;
-  User particiUser;
+  User participateUser;
   Post post;
   Schedule schedule;
   List<Schedule> schedules;
   ReservationDto.Request request;
-  Reservation response;
+  Reservation reservation;
+  List<PostHashtag> tags;
 
   @BeforeEach
   void setUp(WebApplicationContext webApplicationContext,
@@ -87,60 +98,86 @@ public class ReservationDocumentationTests {
             .withRequestDefaults(prettyPrint()).withResponseDefaults(prettyPrint())).build();
 
     // domain for test
-    hostUser = new User();
-    hostUser.setId(1);
-    hostUser.setType(LoginType.GENERAL);
-    hostUser.setEmail("groot@example.com");
-    hostUser.setPassword(passwordEncoder.encode("groot1234*"));
-    hostUser.setNickname("groot-1");
+    hostUser = User.builder()
+        .email("groot@hello.com")
+        .nickname("host")
+        .password(passwordEncoder.encode("groot1234*"))
+        .type(LoginType.GENERAL)
+        .build();
 
-    particiUser = new User();
-    particiUser.setId(2);
-    particiUser.setType(LoginType.GENERAL);
-    particiUser.setEmail("groot22@example.com");
-    particiUser.setPassword(passwordEncoder.encode("groot1234*"));
-    particiUser.setNickname("groot-2");
+    participateUser = User.builder()
+        .email("groot2@hello.com")
+        .nickname("participant")
+        .password(passwordEncoder.encode("groot1234*"))
+        .type(LoginType.GENERAL)
+        .build();
 
     schedules = new ArrayList<>();
-    schedule = new Schedule();
-    schedule.setId(1);
-    schedule.setDate(LocalDate.now());
-    schedule.setRegion("인천");
-    schedule.setPlace("부평역");
-    schedule.setStartTime(LocalTime.of(14, 00));
-    schedule.setEndTime(LocalTime.of(15, 00));
+    schedule = Schedule.builder()
+        .date(Date.valueOf("2022-05-07"))
+        .startTime(Time.valueOf("11:00:00"))
+        .endTime(Time.valueOf("12:00:00"))
+        .region("서대문구")
+        .place("명지대")
+        .build();
     schedules.add(schedule);
 
-    post = new Post();
-    post.setId(1);
-    post.setUser(hostUser);
-    post.setPostHashtags(null);
+    tags = new ArrayList<>();
+    PostHashtag tag = PostHashtag.builder()
+        .hashTag(Hashtag.builder().tag("해시태그").build())
+        .build();
+    tags.add(tag);
+
+    post = Post.builder()
+        .content("내용이다.")
+        .title("제목이다")
+        .credit(CreditType.DIRECT)
+        .imageUrl("이미지 주소다")
+        .postHashtags(tags)
+        .build();
 
     schedule.setPost(post);
 
-    post.setSchedules(schedules);
-    post.setViews(0);
-    post.setTitle("제목이다.");
-    post.setContent("내용이다");
-    post.setCredit(CreditType.DIRECT);
-    post.setImageUrl("이미지 주소다");
+    reservation = Reservation.builder()
+        .schedule(schedule)
+        .hostUser(hostUser)
+        .participateUser(participateUser)
+        .message("msg")
+        .build();
   }
 
   @Test
   @DisplayName("예약조회")
   public void getReservation() throws Exception {
     // given
-    Reservation reservation = reservationEntity();
-    given(reservationService.getReservation(1)).willReturn(reservation);
-    String reservationId = "1";
+    given(reservationService.getReservation(1)).willReturn(reservationRes());
 
     ResultActions result = mockMvc.perform(
         RestDocumentationRequestBuilders
-            .get("/reservation/{reservationId}", reservationId)
+            .get("/reservation/{reservationId}", 1)
             .characterEncoding("utf-8")
             .accept(MediaType.APPLICATION_JSON));
     result.andExpect(status().isOk())
-        .andDo(print());
+        .andDo(print()).andDo(
+            document("get-reservation", getDocumentRequest(), getDocumentResponse(),
+                responseFields(fieldWithPath("status").description("결과 코드"),
+                    fieldWithPath("data.reservationId").description("아이디"),
+                    fieldWithPath("data.imageUrl").type(JsonFieldType.STRING)
+                        .description("이미지 주소"),
+                    fieldWithPath("data.title").type(JsonFieldType.STRING)
+                        .description("포스트 제목"),
+                    fieldWithPath("data.hashtags").type(JsonFieldType.ARRAY)
+                        .description("포스트 해시태그"),
+                    fieldWithPath("data.date").type(JsonFieldType.STRING)
+                        .description("약속 날짜"),
+                    fieldWithPath("data.startTime").type(JsonFieldType.STRING)
+                        .description("약속 시작 시간"),
+                    fieldWithPath("data.endTime").type(JsonFieldType.STRING)
+                        .description("약속 끝 시간"),
+                    fieldWithPath("data.place").type(JsonFieldType.STRING)
+                        .description("약속 장소")))
+        );
+
     verify(reservationService).getReservation(1);
   }
 
@@ -166,8 +203,25 @@ public class ReservationDocumentationTests {
     );
 
     // then
-    resultActions.andExpect(status().isOk()).andDo(print());
-
+    resultActions.andExpect(status().isOk()).andDo(print()).andDo(
+        document("get-host-reservation", getDocumentRequest(), getDocumentResponse(),
+            responseFields(fieldWithPath("status").description("결과 코드"),
+                fieldWithPath("data.[].reservationId").description("아이디"),
+                fieldWithPath("data.[].imageUrl").type(JsonFieldType.STRING)
+                    .description("이미지 주소"),
+                fieldWithPath("data.[].title").type(JsonFieldType.STRING)
+                    .description("포스트 제목"),
+                fieldWithPath("data.[].hashtags").type(JsonFieldType.ARRAY)
+                    .description("포스트 해시태그"),
+                fieldWithPath("data.[].date").type(JsonFieldType.STRING)
+                    .description("약속 날짜"),
+                fieldWithPath("data.[].startTime").type(JsonFieldType.STRING)
+                    .description("약속 시작 시간"),
+                fieldWithPath("data.[].endTime").type(JsonFieldType.STRING)
+                    .description("약속 끝 시간"),
+                fieldWithPath("data.[].place").type(JsonFieldType.STRING)
+                    .description("약속 장소")))
+    );
     verify(reservationService).getHostReservation(anyInt());
 
   }
@@ -194,7 +248,25 @@ public class ReservationDocumentationTests {
     );
 
     // then
-    resultActions.andExpect(status().isOk()).andDo(print());
+    resultActions.andExpect(status().isOk()).andDo(print()).andDo(
+        document("get-participate-reservation", getDocumentRequest(), getDocumentResponse(),
+            responseFields(fieldWithPath("status").description("결과 코드"),
+                fieldWithPath("data.[].reservationId").description("아이디"),
+                fieldWithPath("data.[].imageUrl").type(JsonFieldType.STRING)
+                    .description("이미지 주소"),
+                fieldWithPath("data.[].title").type(JsonFieldType.STRING)
+                    .description("포스트 제목"),
+                fieldWithPath("data.[].hashtags").type(JsonFieldType.ARRAY)
+                    .description("포스트 해시태그"),
+                fieldWithPath("data.[].date").type(JsonFieldType.STRING)
+                    .description("약속 날짜"),
+                fieldWithPath("data.[].startTime").type(JsonFieldType.STRING)
+                    .description("약속 시작 시간"),
+                fieldWithPath("data.[].endTime").type(JsonFieldType.STRING)
+                    .description("약속 끝 시간"),
+                fieldWithPath("data.[].place").type(JsonFieldType.STRING)
+                    .description("약속 장소")))
+    );
 
     verify(reservationService).getUserReservation(anyInt());
   }
@@ -204,13 +276,12 @@ public class ReservationDocumentationTests {
   public void createReservation() throws Exception {
     // given
     request = reservationReq();
-    response = reservationEntity();
 
     when(securityContext.getAuthentication()).thenReturn(authentication);
     SecurityContextHolder.setContext(securityContext);
     when(SecurityContextHolder.getContext().getAuthentication().getPrincipal()).thenReturn(session);
 
-    given(reservationService.createReservation(eq(request), anyInt())).willReturn(response);
+    given(reservationService.createReservation(eq(request), anyInt())).willReturn(reservationRes());
 
     String json = objectMapper.writeValueAsString(request);
 
@@ -224,7 +295,27 @@ public class ReservationDocumentationTests {
 
     // then
     resultActions.andExpect(status().isOk())
-        .andDo(print());
+        .andDo(print()).andDo(
+            document("create-reservation", getDocumentRequest(), getDocumentResponse(),
+                requestFields(fieldWithPath("scheduleId").description("스케쥴 아이디"),
+                    fieldWithPath("message").description("메세지")),
+                responseFields(fieldWithPath("status").description("결과 코드"),
+                    fieldWithPath("data.reservationId").description("아이디"),
+                    fieldWithPath("data.imageUrl").type(JsonFieldType.STRING)
+                        .description("이미지 주소"),
+                    fieldWithPath("data.title").type(JsonFieldType.STRING)
+                        .description("포스트 제목"),
+                    fieldWithPath("data.hashtags").type(JsonFieldType.ARRAY)
+                        .description("포스트 해시태그"),
+                    fieldWithPath("data.date").type(JsonFieldType.STRING)
+                        .description("약속 날짜"),
+                    fieldWithPath("data.startTime").type(JsonFieldType.STRING)
+                        .description("약속 시작 시간"),
+                    fieldWithPath("data.endTime").type(JsonFieldType.STRING)
+                        .description("약속 끝 시간"),
+                    fieldWithPath("data.place").type(JsonFieldType.STRING)
+                        .description("약속 장소")))
+        );
 
   }
 
@@ -244,20 +335,12 @@ public class ReservationDocumentationTests {
 
     //then
     resultActions.andExpect(status().isOk())
-        .andDo(print());
-
+        .andDo(print()).andDo(
+            document("delete-reservation", getDocumentRequest(), getDocumentResponse(),
+                responseFields(fieldWithPath("status").description("결과 코드"),
+                    fieldWithPath("message").description("응답 메세지")))
+        );
     verify(reservationService).deleteReservation(reservationId);
-  }
-
-  private Reservation reservationEntity() {
-    Reservation reservation = new Reservation();
-    reservation.setId(1);
-    reservation.setMessage("msg");
-    reservation.setHostUser(hostUser);
-    reservation.setSchedule(schedule);
-    reservation.setParticipateUser(particiUser);
-
-    return reservation;
   }
 
   private ReservationDto.Request reservationReq() {
@@ -269,16 +352,11 @@ public class ReservationDocumentationTests {
   }
 
   private ReservationDto.Response reservationRes() {
-    return ReservationDto.Response
-        .builder()
-        .reservationId(1)
-        .date(schedule.getDate())
-        .endTime(schedule.getEndTime())
-        .place(schedule.getPlace())
-        .startTime(schedule.getStartTime())
-        .imgUrl(post.getImageUrl())
-        .title(post.getTitle())
-        .hashtags(null)
-        .build();
+    List<String> stringTags = new ArrayList<>();
+    tags.forEach(postHashtag -> stringTags.add(postHashtag.getHashTag().getTag()));
+    ReservationDto.Response response = ReservationMapper
+        .INSTANCE.toResponseDto(reservation, post, schedule);
+    response.setHashtags(stringTags);
+    return response;
   }
 }

--- a/api/src/test/java/grooteogi/ReservationDocumentationTests.java
+++ b/api/src/test/java/grooteogi/ReservationDocumentationTests.java
@@ -107,8 +107,8 @@ public class ReservationDocumentationTests {
     schedule.setDate(LocalDate.now());
     schedule.setRegion("인천");
     schedule.setPlace("부평역");
-    schedule.setStartTime(LocalTime.of(14,00));
-    schedule.setEndTime(LocalTime.of(15,00));
+    schedule.setStartTime(LocalTime.of(14, 00));
+    schedule.setEndTime(LocalTime.of(15, 00));
     schedules.add(schedule);
 
     post = new Post();

--- a/api/src/test/java/grooteogi/ReservationDocumentationTests.java
+++ b/api/src/test/java/grooteogi/ReservationDocumentationTests.java
@@ -220,7 +220,8 @@ public class ReservationDocumentationTests {
   @DisplayName("예약생성")
   public void createReservation() throws Exception {
     // given
-    ReservationDto.Request request = getRequest();
+    final ReservationDto.Request request =
+        ReservationDto.Request.builder().scheduleId(1).message("msg").build();
 
     when(securityContext.getAuthentication()).thenReturn(authentication);
     SecurityContextHolder.setContext(securityContext);
@@ -286,14 +287,6 @@ public class ReservationDocumentationTests {
                     fieldWithPath("message").description("응답 메세지")))
         );
     verify(reservationService).deleteReservation(reservationId);
-  }
-
-  private ReservationDto.Request getRequest() {
-    return ReservationDto.Request
-        .builder()
-        .message("msg")
-        .scheduleId(1)
-        .build();
   }
 
   private ReservationDto.Response getResponse() {

--- a/api/src/test/java/grooteogi/ReservationDocumentationTests.java
+++ b/api/src/test/java/grooteogi/ReservationDocumentationTests.java
@@ -23,8 +23,8 @@ import grooteogi.enums.LoginType;
 import grooteogi.service.ReservationService;
 import grooteogi.utils.JwtProvider;
 import grooteogi.utils.Session;
-import java.sql.Timestamp;
-import java.time.LocalDateTime;
+import java.time.LocalDate;
+import java.time.LocalTime;
 import java.util.ArrayList;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
@@ -104,11 +104,11 @@ public class ReservationDocumentationTests {
     schedules = new ArrayList<>();
     schedule = new Schedule();
     schedule.setId(1);
-    schedule.setDate("2022-05-07");
+    schedule.setDate(LocalDate.now());
     schedule.setRegion("인천");
     schedule.setPlace("부평역");
-    schedule.setStartTime("16:00");
-    schedule.setEndTime("17:00");
+    schedule.setStartTime(LocalTime.of(14,00));
+    schedule.setEndTime(LocalTime.of(15,00));
     schedules.add(schedule);
 
     post = new Post();


### PR DESCRIPTION
## Description
1. Schedule 도메인에서 date, startTime, endTime 타입 변경
2. ReservationDto.Resonse 변경 X
3. 모든 도메인에 아래 어노테이션 추가
``` bash
@Builder
@AllArgsConstructor
@NoArgsConstructor
public class Domain { 
  ....
}
```
4. Post와 PostDto 간의 변수명 동일하게 변경 ( imageUrl )
5. PostMapper로 로직 수정
6. Schedule <> ScheduleDto 간의 date, time 충돌 오류 해결
7. PostDto.Response 임의로 세팅

## Changes
Schedule
- date : String -> Date
- startTime : String -> Time
- endTime : String -> Time

ReservationMapper
toResponse()에서 @Mapping 조건 추가
``` bash
  @Mapping(target = "date", dateFormat = "yyyy-MM-dd")
  @Mapping(target = "startTime", dateFormat = "HH:mm")
  @Mapping(target = "endTime", dateFormat = "HH:mm")
  @Mapping(source = "post.imageUrl", target = "imageUrl")
  ReservationDto.Response toResponseDto(Reservation reservation, Post post, Schedule schedule);
```
Mapping 어노테이션으로 타입 자동 변환

RerservationDocumentationTests 리펙토링
- 빈번하게 사용되는 테스트용 도메인 객체 `ApiDocumentUtils` 인터페이스에 미리 정의

## Note
아래 링크 참고해서 `DateMapper.class` 도입
- 도메인의 Date, Time은 java.sql 라이브러리 사용
- RerservationMapper에서 자동 변환 시, java.util 라이브러리 사용
- 따라서, 충돌 발생
- 이를 해결하기 위해, DateMapper.class로 커스터마이징 처리
[https://mapstruct.org/documentation/stable/reference/html/#invoking-other-mappers](url)