### PR TITLE
fix: Allow s3 deploy on all branches

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,3 +29,5 @@ deploy:
     acl: private
     local_dir: deploy
     wait-until-deployed: true
+    on:
+      all_branches: true


### PR DESCRIPTION
## Related Issue
GRTG-279-deploy-project-buildfile-to-s3

## Description
main 브랜치에서만 배포되도록 되어 있는 설정을 모든 브랜치를 허용하게 수정
-> develop에 머지 시 배포될 수 있도록 변경

## Changes

## Note
