### PR TITLE
chore: Add redis config to resolve redis error

### DIFF
--- a/api/src/main/java/grooteogi/config/RedisConfig.java
+++ b/api/src/main/java/grooteogi/config/RedisConfig.java
@@ -1,0 +1,12 @@
+package grooteogi.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.session.data.redis.config.ConfigureRedisAction;
+
+public class RedisConfig {
+
+  @Bean
+  public ConfigureRedisAction configureRedisAction() {
+    return ConfigureRedisAction.NO_OP;
+  }
+}


### PR DESCRIPTION
## Related Issue
GRTG-283-resolve-deploy-error

## Description
- RedisConfig 추가

## Changes
- ERR unknown command `CONFIG`, with args beginning with: `GET`, `notify-keyspace-events` 에러 해결

## Note
