### PR TITLE
fix: Add configuration annotation to redis config

### DIFF
--- a/api/src/main/java/grooteogi/config/RedisConfig.java
+++ b/api/src/main/java/grooteogi/config/RedisConfig.java
@@ -1,8 +1,10 @@
 package grooteogi.config;
 
 import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
 import org.springframework.session.data.redis.config.ConfigureRedisAction;
 
+@Configuration
 public class RedisConfig {
 
   @Bean


### PR DESCRIPTION
## Related Issue
GRTG-283-resolve-deploy-error

## Description
`@Configuration` 추가

