### PR TITLE
chore: Add redis cluster config on deployment

### DIFF
--- a/api/src/main/java/grooteogi/config/RedisConfig.java
+++ b/api/src/main/java/grooteogi/config/RedisConfig.java
@@ -1,11 +1,30 @@
 package grooteogi.config;
 
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
+import org.springframework.data.redis.connection.RedisClusterConfiguration;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
 import org.springframework.session.data.redis.config.ConfigureRedisAction;
 
 @Configuration
 public class RedisConfig {
+
+  @Value("${spring.redis.host}")
+  private String redisHost;
+
+  @Value("${spring.redis.port}")
+  private Integer redisPort;
+
+  @Profile("!local")
+  @Bean
+  public RedisClusterConfiguration redisClusterConfiguration() {
+    RedisClusterConfiguration clusterConfiguration = new RedisClusterConfiguration();
+    clusterConfiguration.clusterNode(redisHost, redisPort);
+    new LettuceConnectionFactory(clusterConfiguration);
+    return clusterConfiguration;
+  }
 
   @Bean
   public ConfigureRedisAction configureRedisAction() {


### PR DESCRIPTION
## Description
배포 환경에서 사용하는 elastiCache에서 발생한 오류 해결

## Changes
- Redis cluster 설정 추가
  - 로컬 환경인 경우 미적용

## Note
