### PR TITLE
Hotfix/refactor s3 delete logic

### DIFF
--- a/api/src/main/java/grooteogi/domain/Schedule.java
+++ b/api/src/main/java/grooteogi/domain/Schedule.java
@@ -6,6 +6,8 @@ import java.sql.Date;
 import java.sql.Time;
 import javax.persistence.Column;
 import javax.persistence.Entity;
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
@@ -37,6 +39,7 @@ public class Schedule {
   @Column(nullable = false, length = 10)
   private Time endTime;
 
+  @Enumerated(EnumType.STRING)
   @Column(nullable = false, length = 10)
   private RegionType region;
 

--- a/api/src/main/java/grooteogi/domain/Schedule.java
+++ b/api/src/main/java/grooteogi/domain/Schedule.java
@@ -40,7 +40,7 @@ public class Schedule {
   private Time endTime;
 
   @Enumerated(EnumType.STRING)
-  @Column(nullable = false, length = 10)
+  @Column(nullable = false, length = 20)
   private RegionType region;
 
   @Column(length = 40)

--- a/api/src/main/java/grooteogi/service/AwsS3Service.java
+++ b/api/src/main/java/grooteogi/service/AwsS3Service.java
@@ -42,11 +42,12 @@ public class AwsS3Service {
   }
 
   public void deleteImage(String fileName) {
+    String imgUrl = fileName.split("/")[3];
 
-    if (!this.amazonS3Client.doesObjectExist(this.bucket, fileName)) {
+    if (!this.amazonS3Client.doesObjectExist(this.bucket, imgUrl)) {
       throw new ApiException(ApiExceptionEnum.NOT_FOUND_EXCEPTION);
     }
-    amazonS3Client.deleteObject(new DeleteObjectRequest(this.bucket, fileName));
+    amazonS3Client.deleteObject(new DeleteObjectRequest(this.bucket, imgUrl));
   }
 
   private String createFileName(String fileName) {


### PR DESCRIPTION
## Related Issue
s3 delete logic
## Description
- 기존 deleteImage에서 받는 fileName은 이미지에 대한 직접적인 파일 이름을 받았지만
저장할 때 객체 링크를 저장하고 불러올 때도 객체 링크를 통해 불러오기 때문에
이 또한 객체 링크를 집어넣어 split 함수를 통해 파일 이름을 뽑아낼 수 있게 함
## Changes

## Note
