### PR TITLE
refactor: Refactor with deleteImage in S3Service

### DIFF
--- a/api/src/main/java/grooteogi/service/AwsS3Service.java
+++ b/api/src/main/java/grooteogi/service/AwsS3Service.java
@@ -42,11 +42,12 @@ public class AwsS3Service {
   }
 
   public void deleteImage(String fileName) {
+    String imgUrl = fileName.split("/")[3];
 
-    if (!this.amazonS3Client.doesObjectExist(this.bucket, fileName)) {
+    if (!this.amazonS3Client.doesObjectExist(this.bucket, imgUrl)) {
       throw new ApiException(ApiExceptionEnum.NOT_FOUND_EXCEPTION);
     }
-    amazonS3Client.deleteObject(new DeleteObjectRequest(this.bucket, fileName));
+    amazonS3Client.deleteObject(new DeleteObjectRequest(this.bucket, imgUrl));
   }
 
   private String createFileName(String fileName) {


### PR DESCRIPTION
## Related Issue
Refactor with deleteImage in S3Service
## Description
- AwsS3Service 내 deleteImage에서 기존에는 이미지의 직접적인 키 ex)image.png 만 받게 했으나
저장되는 imageUrl이 객체 링크 ex)https://dev-grtg-bucket.s3.ap-northeast-2.amazonaws.com/image.png 인점을 고려하여 객체 링크를 받고 직접적인 키는 split 함수를 통하여 분리시키고, 그 값을 받아 delete하게 함
## Changes
- deleteImage 메소드 내 String imgUrl = fileName.split("/")[3]; 추가
## Note
