### PR TITLE
예약 Response DTO 변경에 따른 리펙토링

### DIFF
--- a/api/src/main/java/grooteogi/dto/ReservationDto.java
+++ b/api/src/main/java/grooteogi/dto/ReservationDto.java
@@ -33,6 +33,8 @@ public class ReservationDto {
     private Boolean isCanceled;
     private String hostPhone;
     private String applyPhone;
+    private String applyNickname;
+    private String text;
   }
 
   @Data

--- a/api/src/main/java/grooteogi/mapper/ReservationMapper.java
+++ b/api/src/main/java/grooteogi/mapper/ReservationMapper.java
@@ -40,10 +40,12 @@ public interface ReservationMapper extends BasicMapper<ReservationDto, Reservati
       @Mapping(target = "postId", source = "post.id"),
       @Mapping(target = "hostPhone", source = "hostPhone"),
       @Mapping(target = "applyPhone", source = "applyPhone"),
-      @Mapping(target = "isCanceled", source = "reservation.isCanceled")
+      @Mapping(target = "isCanceled", source = "reservation.isCanceled"),
+      @Mapping(target = "applyNickname", source = "applyNickname"),
+      @Mapping(target = "text", source = "reservation.message")
   })
   ReservationDto.DetailResponse toDetailResponseDto(Reservation reservation,
-      Post post, Schedule schedule, String hostPhone, String applyPhone);
+      Post post, Schedule schedule, String hostPhone, String applyPhone, String applyNickname);
 
   @Mapping(source = "isCanceled", target = "isCanceled")
   Reservation toModifyIsCanceled(Reservation reservation, boolean isCanceled);

--- a/api/src/main/java/grooteogi/service/ReservationService.java
+++ b/api/src/main/java/grooteogi/service/ReservationService.java
@@ -52,6 +52,7 @@ public class ReservationService {
         reservation.get().getHostUser().getUserInfo().getContact());
     Optional<String> participateUserPhone = Optional.ofNullable(
         reservation.get().getParticipateUser().getUserInfo().getContact());
+    String participateUserNickname = reservation.get().getParticipateUser().getNickname();
 
     hostUserPhone.orElseThrow(() -> new ApiException(ApiExceptionEnum.CONTACT_NOT_FOUND_EXCEPTION));
     participateUserPhone
@@ -59,7 +60,7 @@ public class ReservationService {
 
 
     return ReservationMapper.INSTANCE.toDetailResponseDto(reservation.get(), post, schedule,
-        hostUserPhone.get(), participateUserPhone.get());
+        hostUserPhone.get(), participateUserPhone.get(), participateUserNickname);
   }
 
   public List<ReservationDto.DetailResponse> getReservation(boolean isHost, Integer userId,
@@ -124,9 +125,11 @@ public class ReservationService {
       participateUserPhone
           .orElseThrow(() -> new ApiException(ApiExceptionEnum.CONTACT_NOT_FOUND_EXCEPTION));
 
+      String participateUserNickname = reservation.getParticipateUser().getNickname();
+
       ReservationDto.DetailResponse detailResponse =
           ReservationMapper.INSTANCE.toDetailResponseDto(reservation, post, schedule,
-              hostUserPhone.get(), participateUserPhone.get());
+              hostUserPhone.get(), participateUserPhone.get(), participateUserNickname);
       detailResponse.setHashtags(getTags(post.getPostHashtags()));
       responseList.add(detailResponse);
     });

--- a/api/src/test/java/grooteogi/ReservationDocumentationTests.java
+++ b/api/src/test/java/grooteogi/ReservationDocumentationTests.java
@@ -86,6 +86,8 @@ public class ReservationDocumentationTests {
           .title("개발이 좋아?")
           .applyPhone("01012345678")
           .hostPhone("01098765432")
+          .text("잘부탁드려요.")
+          .applyNickname("새내기")
           .build();
 
   private final ReservationDto.Response createResponse =
@@ -135,7 +137,9 @@ public class ReservationDocumentationTests {
                     fieldWithPath("data.imageUrl").description("포스트 이미지 url"),
                     fieldWithPath("data.isCanceled").description("약속 취소 여부"),
                     fieldWithPath("data.hostPhone").description("멘토 연락처"),
-                    fieldWithPath("data.applyPhone").description("멘티 연락처")
+                    fieldWithPath("data.applyPhone").description("멘티 연락처"),
+                    fieldWithPath("data.applyNickname").description("멘티 닉네임"),
+                    fieldWithPath("data.text").description("호스트에게 남기는 말")
                 )
             )
         );
@@ -185,7 +189,9 @@ public class ReservationDocumentationTests {
                     fieldWithPath("data.[].imageUrl").description("포스트 이미지 url"),
                     fieldWithPath("data.[].isCanceled").description("약속 취소 여부"),
                     fieldWithPath("data.[].hostPhone").description("멘토 연락처"),
-                    fieldWithPath("data.[].applyPhone").description("멘티 연락처")
+                    fieldWithPath("data.[].applyPhone").description("멘티 연락처"),
+                    fieldWithPath("data.[].applyNickname").description("멘티 닉네임"),
+                    fieldWithPath("data.[].text").description("호스트에게 남기는 말")
                 )
             )
         );
@@ -235,7 +241,9 @@ public class ReservationDocumentationTests {
                     fieldWithPath("data.[].imageUrl").description("포스트 이미지 url"),
                     fieldWithPath("data.[].isCanceled").description("약속 취소 여부"),
                     fieldWithPath("data.[].hostPhone").description("멘토 연락처"),
-                    fieldWithPath("data.[].applyPhone").description("멘티 연락처")
+                    fieldWithPath("data.[].applyPhone").description("멘티 연락처"),
+                    fieldWithPath("data.[].applyNickname").description("멘티 닉네임"),
+                    fieldWithPath("data.[].text").description("호스트에게 남기는 말")
                 )
             )
         );


### PR DESCRIPTION
## Description
- 예약 Response DTO 필드 추가 ( 참가자 닉네임, 예약 시  남기는 말 )
- 예약 Mapper 매핑 조건 추가
- 예약 서비스에서 DetailResponse 리턴하는 모든 get 요청 로직 수정 
- DTO 변경에 따른 예약 테스트 코드 문서화 시, fields 추가

## Note
```` bash
{
    "status": 200,
    "message": "get reservation success",
    "data": {
        "title": "test-title26",
        "date": "2022-05-29",
        "startTime": "14:00:00",
        "endTime": "15:00:00",
        "region": "SEODAEMUN",
        "place": "우물카페",
        "postId": 1,
        "imageUrl": "",
        "isCanceled": false,
        "hostPhone": "01098765432",
        "applyPhone": "01012345678",
        "applyNickname": "groot-2",
        "text": "dto 수정 후 테스트"
    }
}
````

포스트맨으로 테스트 후에 보여지는 결과값