### PR TITLE
해시태그 검색 로직 수정

### DIFF
--- a/api/src/main/java/grooteogi/mapper/HashtagMapper.java
+++ b/api/src/main/java/grooteogi/mapper/HashtagMapper.java
@@ -14,9 +14,9 @@ public interface HashtagMapper extends BasicMapper<HashtagDto, Hashtag> {
 
   HashtagMapper INSTANCE = Mappers.getMapper(HashtagMapper.class);
 
-  @Mapping(source = "dto.name", target = "name")
+  @Mapping(source = "dto", target = "name")
   @Mapping(target = "id", ignore = true)
-  Hashtag toEntity(HashtagDto.Request dto);
+  Hashtag toEntity(String dto);
 
   @Mappings({
       @Mapping(source = "hashtag.id", target = "hashtagId"),

--- a/api/src/main/java/grooteogi/mapper/HashtagMapper.java
+++ b/api/src/main/java/grooteogi/mapper/HashtagMapper.java
@@ -14,9 +14,9 @@ public interface HashtagMapper extends BasicMapper<HashtagDto, Hashtag> {
 
   HashtagMapper INSTANCE = Mappers.getMapper(HashtagMapper.class);
 
-  @Mapping(source = "dto", target = "name")
+  @Mapping(source = "name", target = "name")
   @Mapping(target = "id", ignore = true)
-  Hashtag toEntity(String dto);
+  Hashtag toEntity(String name);
 
   @Mappings({
       @Mapping(source = "hashtag.id", target = "hashtagId"),

--- a/api/src/main/java/grooteogi/service/HashtagService.java
+++ b/api/src/main/java/grooteogi/service/HashtagService.java
@@ -10,6 +10,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -26,7 +27,7 @@ public class HashtagService {
       throw new ApiException(ApiExceptionEnum.DUPLICATION_VALUE_EXCEPTION);
     }
 
-    Hashtag createdHashtag = HashtagMapper.INSTANCE.toEntity(request);
+    Hashtag createdHashtag = HashtagMapper.INSTANCE.toEntity(request.getName());
     Hashtag savedHashtag = hashtagRepository.save(createdHashtag);
 
     return HashtagMapper.INSTANCE.toResponseDto(savedHashtag);
@@ -45,15 +46,18 @@ public class HashtagService {
   }
 
   public HashtagDto.Response search(String keyword) {
-    Optional<Hashtag> findHashtag = this.hashtagRepository.findByName(keyword);
 
-    if (findHashtag.isEmpty()) {
-      Hashtag createdHashtag = Hashtag.builder().name(keyword).build();
-      hashtagRepository.save(createdHashtag);
-      return HashtagMapper.INSTANCE.toResponseDto(createdHashtag);
+    Optional<Hashtag> hashtag = (keyword == null || keyword.equals("")) ? hashtagRepository.findAll(
+        Sort.by(Sort.Direction.DESC, "count")).stream().findFirst()
+        : hashtagRepository.findByName(keyword);
+
+    if (hashtag.isEmpty()) {
+      Hashtag createdHashtag = HashtagMapper.INSTANCE.toEntity(keyword);
+      Hashtag savedHashtag = hashtagRepository.save(createdHashtag);
+      return HashtagMapper.INSTANCE.toResponseDto(savedHashtag);
     }
 
-    return HashtagMapper.INSTANCE.toResponseDto(findHashtag.get());
+    return HashtagMapper.INSTANCE.toResponseDto(hashtag.get());
   }
 
 }


### PR DESCRIPTION
## Description
[문제 상황]
Request Param이 없거나 `""` 인 경우, `""` 인 hashtag가 생성.

[변경된 로직]
Request Param이 없거나 `""` 인 경우, 가장 많이 사용된 해시태그를 반환

[매퍼 수정]
해시태그 생성 시, 매퍼에 넘기는 파라미터를 Request 객체가 아닌, string 으로 변경
해시태그 검색에서 검색어에 해당하는 해시태그가 존재하지 않는다면,  새로 생성할 때 사용하기 위함
