### PR TITLE
Auth DTO 이메일 어노테이션 수정 및 회원 탈퇴 request param 삭제

### DIFF
--- a/api/src/main/java/grooteogi/controller/AuthController.java
+++ b/api/src/main/java/grooteogi/controller/AuthController.java
@@ -12,12 +12,14 @@ import grooteogi.response.BasicResponse;
 import grooteogi.service.AuthService;
 import grooteogi.service.UserService;
 import grooteogi.utils.OauthClient;
+import grooteogi.utils.Session;
 import javax.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseCookie;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.validation.BindingResult;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -67,15 +69,17 @@ public class AuthController {
   }
 
   @DeleteMapping("/auth/withdrawal")
-  public ResponseEntity withdrawal(@RequestParam("user-id") Integer userId) {
-    authService.withdrawal(userId);
+  public ResponseEntity withdrawal() {
+    Session session = (Session) SecurityContextHolder.getContext().getAuthentication()
+        .getPrincipal();
+    authService.withdrawal(session.getId());
 
     return ResponseEntity.ok(BasicResponse.builder().message("delete user success").build());
   }
 
   @PostMapping("/auth/email/send")
   public ResponseEntity<BasicResponse> sendVerifyEmail(
-      @RequestBody AuthDto.SendEmailRequest request) {
+      @Valid @RequestBody AuthDto.SendEmailRequest request) {
 
     String email = request.getEmail();
 
@@ -91,7 +95,7 @@ public class AuthController {
 
   @PostMapping("/auth/email/check")
   public ResponseEntity<BasicResponse> checkVerifyEmail(
-      @RequestBody AuthDto.CheckEmailRequest request) {
+      @Valid @RequestBody AuthDto.CheckEmailRequest request) {
     authService.checkVerifyEmail(request);
 
     return ResponseEntity.ok(

--- a/api/src/main/java/grooteogi/dto/AuthDto.java
+++ b/api/src/main/java/grooteogi/dto/AuthDto.java
@@ -1,6 +1,6 @@
 package grooteogi.dto;
 
-import javax.validation.constraints.Email;
+import com.fasterxml.jackson.annotation.JsonCreator;
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Pattern;
@@ -36,16 +36,23 @@ public class AuthDto {
   @Builder
   public static class SendEmailRequest {
 
-    @Email
+    @Pattern(regexp = "^[a-zA-Z0-9+-\\_.]+@[a-zA-Z0-9-]+\\.[a-zA-Z0-9-.]+$",
+        message = "이메일 형식에 맞게 입력해주세요.")
     @NotBlank(message = "이메일을 입력해주세요.")
     private String email;
+
+    @JsonCreator
+    public SendEmailRequest(String email) {
+      this.email = email;
+    }
   }
 
   @Data
   @Builder
   public static class CheckEmailRequest {
 
-    @Email
+    @Pattern(regexp = "^[a-zA-Z0-9+-\\_.]+@[a-zA-Z0-9-]+\\.[a-zA-Z0-9-.]+$",
+        message = "이메일 형식에 맞게 입력해주세요.")
     @NotBlank(message = "이메일을 입력해주세요.")
     private String email;
 

--- a/api/src/main/java/grooteogi/exception/ApiExceptionEnum.java
+++ b/api/src/main/java/grooteogi/exception/ApiExceptionEnum.java
@@ -51,6 +51,7 @@ public enum ApiExceptionEnum {
   NO_CREATE_REVIEW_EXCEPTION(HttpStatus.FORBIDDEN, "리뷰 작성 가능 기간이 아닙니다."),
   // Permission Exception
   INVALID_CODE_EXCEPTION(HttpStatus.NOT_FOUND, "인증코드를 다시 확인해주세요."),
+  TIME_OUT_EXCEPTION(HttpStatus.BAD_REQUEST, "유효시간이 종료되었습니다.")
   ;
 
   private final HttpStatus httpStatus;

--- a/api/src/main/java/grooteogi/service/AuthService.java
+++ b/api/src/main/java/grooteogi/service/AuthService.java
@@ -96,7 +96,7 @@ public class AuthService {
   }
 
   public void sendVerifyEmail(String email) {
-    String code = emailClient.createCode();
+    String code = EmailClient.createCode();
     emailClient.send(email, code);
 
     String key = prefix + email;
@@ -105,8 +105,11 @@ public class AuthService {
 
   public void checkVerifyEmail(AuthDto.CheckEmailRequest request) {
     String key = prefix + request.getEmail();
-    String value = redisClient.getValue(key);
-    if (value == null || !value.equals(request.getCode())) {
+    Optional<String> value = Optional.ofNullable(redisClient.getValue(key));
+
+    value.orElseThrow(() -> new ApiException(ApiExceptionEnum.TIME_OUT_EXCEPTION));
+
+    if (!value.get().equals(request.getCode())) {
       throw new ApiException(ApiExceptionEnum.INVALID_CODE_EXCEPTION);
     }
   }


### PR DESCRIPTION
## Description
- DTO에 존재하는 모든 이메일 형식 체크 방식 통일화
- 회원 탈퇴 시, Request Param 삭제 및 세션에서 Id 찾아오는 방식으로 수정
- 이메일 인증 코드 확인 시, time-out 오류 추가 