### PR TITLE
포스트 Detail response 로직 수정

### DIFF
--- a/api/src/main/java/grooteogi/service/PostService.java
+++ b/api/src/main/java/grooteogi/service/PostService.java
@@ -71,6 +71,8 @@ public class PostService {
 
     PostDto.Response result = PostMapper.INSTANCE.toDetailResponse(updatePost);
 
+    result.setHashtags(getPostHashtags(updatePost.getPostHashtags()));
+
     User user = post.get().getUser();
     result.setMentor(PostMapper.INSTANCE.toUserResponse(user, user.getUserInfo()));
 
@@ -102,10 +104,10 @@ public class PostService {
     return schedules;
   }
 
-  private List<String> getPostHashtags(List<PostHashtag> postHashtags) {
+  private String[] getPostHashtags(List<PostHashtag> postHashtags) {
     List<String> response = new ArrayList<>();
     postHashtags.forEach(postHashtag -> response.add(postHashtag.getHashTag().getName()));
-    return response;
+    return response.toArray(new String[0]);
   }
 
   public List<PostDto.SearchResult> getLikePosts(Integer userId) {


### PR DESCRIPTION
## Description
response에 해시태그 set하는 코드 누락으로 발생한 이슈 해결

```` bash
public PostDto.Response getPostResponse(Integer postId, String jwt) {
    Optional<Post> post = postRepository.findById(postId);
    if (post.isEmpty()) {
      throw new ApiException(ApiExceptionEnum.POST_NOT_FOUND_EXCEPTION);
    }

    //조회수 증가
    post.get().setViews(post.get().getViews() + 1);
    Post updatePost = postRepository.save(post.get());

    PostDto.Response result = PostMapper.INSTANCE.toDetailResponse(updatePost);

    result.setHashtags(getPostHashtags(updatePost.getPostHashtags()));

    User user = post.get().getUser();
    result.setMentor(PostMapper.INSTANCE.toUserResponse(user, user.getUserInfo()));

    List<Heart> hearts = heartRepository.findByPost(post.get());

    if (jwt != null) {
      jwt = jwtProvider.extractToken(jwt);
      jwtProvider.isUsable(jwt);
      Session session = jwtProvider.extractAllClaims(jwt);

      Optional<Heart> heart =
          heartRepository.findByPostIdUserId(post.get().getId(), session.getId());
      LikeDto.Response likeResponse =
          LikeDto.Response.builder().liked(!heart.isEmpty()).count(hearts.size()).build();
      result.setLikes(likeResponse);
    } else {
      LikeDto.Response likeResponse =
          LikeDto.Response.builder().liked(false).count(hearts.size()).build();
      result.setLikes(likeResponse);
    }

    return result;
  }
````
위의 코드에서 ` result.setHashtags(getPostHashtags(updatePost.getPostHashtags()));` 코드 추가하면 이슈 해결

아래는 포스트맨으로 테스트한 결과

![image](https://user-images.githubusercontent.com/61505572/171335880-ea9617b3-0cfd-4032-b385-192f79ecdbdd.png)

