### PR TITLE
비밀번호 변경 Request DTO 변경에 따른 로직 수정

### DIFF
--- a/api/src/main/java/grooteogi/dto/UserDto.java
+++ b/api/src/main/java/grooteogi/dto/UserDto.java
@@ -1,19 +1,16 @@
 package grooteogi.dto;
 
-import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
-import lombok.NoArgsConstructor;
 
 public class UserDto {
 
   @Data
   @Builder
-  @AllArgsConstructor
-  @NoArgsConstructor
   public static class PasswordRequest {
 
-    String password;
+    String currentPassword;
+    String newPassword;
   }
 
   @Data

--- a/api/src/main/java/grooteogi/exception/ApiExceptionEnum.java
+++ b/api/src/main/java/grooteogi/exception/ApiExceptionEnum.java
@@ -24,6 +24,7 @@ public enum ApiExceptionEnum {
   USER_NOT_FOUND_EXCEPTION(HttpStatus.NOT_FOUND, "유저를 찾을 수 없습니다."),
   EMAIL_DUPLICATION_EXCEPTION(HttpStatus.CONFLICT, "이미 존재하는 이메일입니다."),
   PASSWORD_VALUE_EXCEPTION(HttpStatus.BAD_REQUEST, "비밀번호는 영문과 특수문자 숫자를 포함하며 8자 이상이어야 합니다."),
+  PASSWORD_DISCORD_EXCEPTION(HttpStatus.NOT_FOUND, "현재 비밀번호가 일치하지 않습니다."),
   // Token Exception
   EXPIRED_TOKEN_EXCEPTION(HttpStatus.UNAUTHORIZED, "만료된 토큰입니다."),
   EXPIRED_REFRESH_TOKEN_EXCEPTION(HttpStatus.UNAUTHORIZED, "만료된 토큰입니다. 회원가입을 다시 시도하십시오."),

--- a/api/src/main/java/grooteogi/service/UserService.java
+++ b/api/src/main/java/grooteogi/service/UserService.java
@@ -84,12 +84,16 @@ public class UserService {
     Optional<User> user = userRepository.findById(userId);
     user.orElseThrow(() -> new ApiException(ApiExceptionEnum.USER_NOT_FOUND_EXCEPTION));
 
-    if (passwordEncoder.matches(request.getPassword(), user.get().getPassword())) {
+    if (!passwordEncoder.matches(request.getCurrentPassword(), user.get().getPassword())) {
+      throw new ApiException(ApiExceptionEnum.PASSWORD_DISCORD_EXCEPTION);
+    }
+
+    if (request.getCurrentPassword().equals(request.getNewPassword())) {
       throw new ApiException(ApiExceptionEnum.DUPLICATION_VALUE_EXCEPTION);
     }
 
-    validator.confirmPasswordVerification(request.getPassword());
-    user.get().setPassword(passwordEncoder.encode(request.getPassword()));
+    validator.confirmPasswordVerification(request.getNewPassword());
+    user.get().setPassword(passwordEncoder.encode(request.getNewPassword()));
     userRepository.save(user.get());
   }
 

--- a/api/src/test/java/grooteogi/UserDocumentationTests.java
+++ b/api/src/test/java/grooteogi/UserDocumentationTests.java
@@ -87,7 +87,8 @@ public class UserDocumentationTests {
           .build();
   private final UserDto.PasswordRequest passwordRequest =
       UserDto.PasswordRequest.builder()
-          .password("groot1234*")
+          .currentPassword("groot1234*")
+          .newPassword("abcd1234!")
           .build();
 
   @BeforeEach
@@ -183,7 +184,8 @@ public class UserDocumentationTests {
         .andDo(
             document("password-modify", getDocumentRequest(), getDocumentResponse(),
                 requestFields(
-                    fieldWithPath("password").description("비밀번호")
+                    fieldWithPath("currentPassword").description("현재 비밀번호"),
+                    fieldWithPath("newPassword").description("새 비밀번호")
                 ),
                 responseFields(
                     fieldWithPath("status").description("결과 코드"),


### PR DESCRIPTION
## Description

[GRTG-380](https://babiyak.atlassian.net/jira/software/c/projects/GRTG/boards/1/backlog?view=detail&selectedIssue=GRTG-380&issueLimit=100)

```` bash
  public void modifyUserPw(Integer userId, UserDto.PasswordRequest request) {
    Optional<User> user = userRepository.findById(userId);
    user.orElseThrow(() -> new ApiException(ApiExceptionEnum.USER_NOT_FOUND_EXCEPTION));

    if (!passwordEncoder.matches(request.getCurrentPassword(), user.get().getPassword())) {
      throw new ApiException(ApiExceptionEnum.PASSWORD_DISCORD_EXCEPTION);
    }

    if (request.getCurrentPassword().equals(request.getNewPassword())) {
      throw new ApiException(ApiExceptionEnum.DUPLICATION_VALUE_EXCEPTION);
    }

    validator.confirmPasswordVerification(request.getNewPassword());
    user.get().setPassword(passwordEncoder.encode(request.getNewPassword()));
    userRepository.save(user.get());
  }
````

1. 현재 비밀번호가 DB에 저장된 비밀번호가 맞는지 확인
2. 현재 비밀번호와 새 비밀번호가 같은 지 확인
3. 새 비밀번호 유효성 검사
4. 위의 3단계를 모두 통과 시, DB에 업데이트

아래는 포스트맨으로 테스트한 화면

** DB에 저장되어 있는 유저로 로그인**

![image](https://user-images.githubusercontent.com/61505572/171343726-7c2c16d9-0dba-477c-be9e-7acd26f1e263.png)

** 비밀번호 변경 **

![image](https://user-images.githubusercontent.com/61505572/171343868-6da9d4f9-7d65-465e-b9cd-80e9799ced24.png)

** 변경 전 비밀번호로 로그인 시, **

![image](https://user-images.githubusercontent.com/61505572/171343951-a896964e-3c69-45f2-aeeb-b00cf33a65d5.png)

로그인 실패 오류 발생시킴.

** 변경 후 비밀번호로 로그인 시, **

![image](https://user-images.githubusercontent.com/61505572/171344095-384783f9-4030-43c4-82ad-ec3d193f5c90.png)

로그인 성공