### PR TITLE
feat: add isAuthor in postDto and set about that in postService

### DIFF
--- a/api/src/main/java/grooteogi/dto/PostDto.java
+++ b/api/src/main/java/grooteogi/dto/PostDto.java
@@ -64,6 +64,7 @@ public class PostDto {
     private CreditType creditType;
     private LikeDto.Response likes;
     private UserDto.Response mentor;
+    private Boolean isAuthor;
   }
 
   @Data

--- a/api/src/main/java/grooteogi/service/PostService.java
+++ b/api/src/main/java/grooteogi/service/PostService.java
@@ -75,6 +75,8 @@ public class PostService {
 
     User user = post.get().getUser();
     result.setMentor(PostMapper.INSTANCE.toUserResponse(user, user.getUserInfo()));
+    result.setIsAuthor(false);
+
 
     List<Heart> hearts = heartRepository.findByPost(post.get());
 
@@ -82,6 +84,10 @@ public class PostService {
       jwt = jwtProvider.extractToken(jwt);
       jwtProvider.isUsable(jwt);
       Session session = jwtProvider.extractAllClaims(jwt);
+
+      if (result.getMentor().getUserId() == (session.getId())) {
+        result.setIsAuthor(true);
+      }
 
       Optional<Heart> heart =
           heartRepository.findByPostIdUserId(post.get().getId(), session.getId());


### PR DESCRIPTION
## Related Issue
feat: add isAuthor in postDto and set about that in postService
## Description
<img width="284" alt="스크린샷 2022-06-01 오후 6 24 24" src="https://user-images.githubusercontent.com/58325848/171372304-afe9ef73-26f2-4891-86f2-f4855f5753a2.png">

- post detail에서 isAuthor 확인할 수 있게 postDto response에 attribute 추가
- postservice에서 멘토 id가 session id와 같다면 isAuthor true, 아닐 경우 false

## Changes

## Note
