### PR TITLE
유저 닉네임 변경 로직 오류 해결

### DIFF
--- a/api/src/main/java/grooteogi/mapper/UserMapper.java
+++ b/api/src/main/java/grooteogi/mapper/UserMapper.java
@@ -39,9 +39,9 @@ public interface UserMapper extends BasicMapper<AuthDto, User> {
   @Mappings({
       @Mapping(source = "user.id", target = "id"),
       @Mapping(source = "userInfo.id", target = "userInfo.id"),
-      @Mapping(source = "user.nickname", target = "nickname"),
+      @Mapping(source = "nickname", target = "nickname"),
       @Mapping(target = "createAt", ignore = true),
       @Mapping(target = "updateAt", ignore = true)
   })
-  User toModify(User user, UserInfo userInfo);
+  User toModify(User user, String nickname, UserInfo userInfo);
 }

--- a/api/src/main/java/grooteogi/service/AuthService.java
+++ b/api/src/main/java/grooteogi/service/AuthService.java
@@ -66,7 +66,8 @@ public class AuthService {
 
     UserInfo userInfo = userInfoRepository.save(new UserInfo());
 
-    User modifiedUser = UserMapper.INSTANCE.toModify(registerUser, userInfo);
+    User modifiedUser = UserMapper.INSTANCE.toModify(registerUser,
+        registerUser.getNickname(), userInfo);
     userRepository.save(modifiedUser);
 
     return UserMapper.INSTANCE.toResponseDto(modifiedUser, modifiedUser.getUserInfo());

--- a/api/src/main/java/grooteogi/service/UserService.java
+++ b/api/src/main/java/grooteogi/service/UserService.java
@@ -75,7 +75,7 @@ public class UserService {
 
     UserInfo userInfo = userInfoRepository.save(UserInfoMapper.INSTANCE.toEntity(request));
 
-    User modifiedUser = UserMapper.INSTANCE.toModify(user.get(), userInfo);
+    User modifiedUser = UserMapper.INSTANCE.toModify(user.get(), request.getNickname(), userInfo);
 
     userRepository.save(modifiedUser);
   }


### PR DESCRIPTION
## Related Issue
[GRTG-383](https://babiyak.atlassian.net/jira/software/c/projects/GRTG/boards/1/backlog?view=detail&selectedIssue=GRTG-383&issueLimit=100)

## Description
유저 닉네임 변경 시, mapper에서 parameter 누락으로 인해 변경이 안되는 오류 발생

```` bash
public void modifyUserProfile(Integer userId, ProfileDto.Request request) {
    Optional<User> user = userRepository.findById(userId);
    user.orElseThrow(() -> new ApiException(ApiExceptionEnum.USER_NOT_FOUND_EXCEPTION));

    if (!user.get().getNickname().equals(request.getNickname())
        && userRepository.existsByNickname(request.getNickname())) {
      throw new ApiException(ApiExceptionEnum.DUPLICATION_VALUE_EXCEPTION);
    }

    UserInfo userInfo = userInfoRepository.save(UserInfoMapper.INSTANCE.toEntity(request));

    User modifiedUser = UserMapper.INSTANCE.toModify(user.get(), request.getNickname(), userInfo);

    userRepository.save(modifiedUser);
  }

````

`User modifiedUser = UserMapper.INSTANCE.toModify(user.get(), request.getNickname(), userInfo);` 여기서 request로부터 넘어온 nickname 넣어주기

```` bash
  @Mappings({
      @Mapping(source = "user.id", target = "id"),
      @Mapping(source = "userInfo.id", target = "userInfo.id"),
      @Mapping(source = "nickname", target = "nickname"),
      @Mapping(target = "createAt", ignore = true),
      @Mapping(target = "updateAt", ignore = true)
  })
  User toModify(User user, String nickname, UserInfo userInfo);
```` 
Mapper에서는 위와 같이 mapping 조건 수정 및 param 넣어 주기

아래는 포스트맨으로 테스트 

현재 DB에 담긴 유저의 nickname = 짱구
![image](https://user-images.githubusercontent.com/61505572/171602381-bcdb2372-7a9a-4a8c-aafa-dbaf681c8890.png)

**nickname = 철수** 로 변경

![image](https://user-images.githubusercontent.com/61505572/171602633-14b735e9-3a2e-4830-84ff-ce9b317b2eea.png)

![image](https://user-images.githubusercontent.com/61505572/171602695-0d97ca1f-db91-4698-8107-8a2941cfcfbf.png)

철수로 nickname 변경 성공