### PR TITLE
지역 Enum to String 변경 함수 생성 및 적용

### DIFF
--- a/api/src/main/java/grooteogi/enums/RegionType.java
+++ b/api/src/main/java/grooteogi/enums/RegionType.java
@@ -36,6 +36,10 @@ public enum RegionType {
     this.label = label;
   }
 
+  public String getLabel() {
+    return this.label;
+  }
+
   public static RegionType getEnum(String label) {
     return Arrays.stream(RegionType.values())
         .filter(regionType -> regionType.label.equals(label))

--- a/api/src/main/java/grooteogi/enums/RegionType.java
+++ b/api/src/main/java/grooteogi/enums/RegionType.java
@@ -36,6 +36,7 @@ public enum RegionType {
     this.label = label;
   }
 
+  @Override
   public String toString() {
     return this.label;
   }

--- a/api/src/main/java/grooteogi/enums/RegionType.java
+++ b/api/src/main/java/grooteogi/enums/RegionType.java
@@ -36,7 +36,7 @@ public enum RegionType {
     this.label = label;
   }
 
-  public String getLabel() {
+  public String toString() {
     return this.label;
   }
 

--- a/api/src/main/java/grooteogi/mapper/PostMapper.java
+++ b/api/src/main/java/grooteogi/mapper/PostMapper.java
@@ -86,7 +86,7 @@ public interface PostMapper extends BasicMapper<PostDto, Post> {
   ScheduleDto.Response toScheduleResponses(Schedule schedules);
 
   default String asStringRegion(RegionType type) {
-    return type != null ? type.toString() : null;
+    return type != null ? type.getLabel() : null;
   }
 
   default RegionType asRegionType(String region) {

--- a/api/src/main/java/grooteogi/mapper/PostMapper.java
+++ b/api/src/main/java/grooteogi/mapper/PostMapper.java
@@ -86,7 +86,7 @@ public interface PostMapper extends BasicMapper<PostDto, Post> {
   ScheduleDto.Response toScheduleResponses(Schedule schedules);
 
   default String asStringRegion(RegionType type) {
-    return type != null ? type.getLabel() : null;
+    return type != null ? type.toString() : null;
   }
 
   default RegionType asRegionType(String region) {


### PR DESCRIPTION
## Related Issue
[GRTG-384](https://babiyak.atlassian.net/jira/software/c/projects/GRTG/boards/1/backlog?view=detail&selectedIssue=GRTG-384&issueLimit=100)
## Description
문제 상황 : Region 값이 영어로 return 된다.
원인 : ReginType `Enum to string` 시, `toString()` 메소드 overriding 문제
해결 : String으로 변경해주는 함수를 enum class에 생성

```` bash
   ...
  GANGBUK("강북구"),
  DOBONG("도봉구")
  ;

  private final String label;

  RegionType(String label) {
    this.label = label;
  }

  public String getLabel() {
    return this.label;
  }
````
위의 enum class에서 `getLabel()` 함수 생성

```` bash
  default String asStringRegion(RegionType type) {
    return type != null ? type.getLabel() : null;
  }
````
위의 PostMapper.java에서 `asStringRegion()` 리턴 시, type.toString() -> type.getLabel() 로 변경

아래는 포스트맨으로 테스트
![image](https://user-images.githubusercontent.com/61505572/171620090-bd670fcb-7a3b-4bf1-a543-a07c66d7bf23.png)
