### PR TITLE
hotfix: refactoring about create postHashtag logic

### DIFF
--- a/api/src/main/java/grooteogi/service/PostService.java
+++ b/api/src/main/java/grooteogi/service/PostService.java
@@ -77,7 +77,6 @@ public class PostService {
     result.setMentor(PostMapper.INSTANCE.toUserResponse(user, user.getUserInfo()));
     result.setIsAuthor(false);
 
-
     List<Heart> hearts = heartRepository.findByPost(post.get());
 
     if (jwt != null) {
@@ -134,6 +133,11 @@ public class PostService {
     List<PostHashtag> postHashtagList = new ArrayList<>();
     Arrays.stream(postHashtags).forEach(name -> {
       Optional<Hashtag> hashtag = hashtagRepository.findByName(name);
+      if (hashtag.isEmpty()) {
+        Hashtag createdHashtag = Hashtag.builder().name(name).build();
+        hashtagRepository.save(createdHashtag);
+        hashtag = hashtagRepository.findByName(name);
+      }
       hashtag.ifPresent(tag -> {
         tag.setCount(tag.getCount() + 1);
         PostHashtag createdPostHashtag = PostHashtag.builder().hashTag(tag).build();

--- a/api/src/main/java/grooteogi/service/PostService.java
+++ b/api/src/main/java/grooteogi/service/PostService.java
@@ -201,12 +201,18 @@ public class PostService {
       PostHashtag modifiedPostHashtag = new PostHashtag();
       Optional<Hashtag> hashtag = hashtagRepository.findByName(name);
 
+      if (hashtag.isEmpty()) {
+        Hashtag createdHashtag = Hashtag.builder().name(name).build();
+        hashtagRepository.save(createdHashtag);
+        hashtag = hashtagRepository.findByName(name);
+      }
+
       hashtag.ifPresent(tag -> {
         tag.setCount(tag.getCount() + 1);
         modifiedPostHashtag.setHashTag(tag);
         modifiedPostHashtag.setPost(post.get());
 
-        post.get().getPostHashtags().add(modifiedPostHashtag);
+        postHashtagRepository.save(modifiedPostHashtag);
       });
     });
 


### PR DESCRIPTION
## Related Issue
포스트 생성 api에서 해시태그 fetch하도록 리팩터링
## Description
<img width="474" alt="스크린샷 2022-06-02 오후 9 11 45" src="https://user-images.githubusercontent.com/58325848/171626425-3769a27f-28f2-4576-850c-9fb3550d50ac.png">
- 포스트 해시태그 create 할 때 optional로 받아온 해시태그가 비었을 경우 hashtag 새로 생성하게 함

## Changes


## Note
