### PR TITLE
hotfix: remove sms response

### DIFF
--- a/api/src/main/java/grooteogi/controller/ReservationController.java
+++ b/api/src/main/java/grooteogi/controller/ReservationController.java
@@ -1,7 +1,6 @@
 package grooteogi.controller;
 
 import grooteogi.dto.ReservationDto;
-import grooteogi.dto.ReservationDto.SendSmsResponse;
 import grooteogi.response.BasicResponse;
 import grooteogi.service.ReservationService;
 import grooteogi.utils.Session;
@@ -81,9 +80,9 @@ public class ReservationController {
   
   @PostMapping("/sms/send")
   public ResponseEntity<BasicResponse> sendSms(@RequestParam String phoneNumber) {
-    SendSmsResponse response = this.reservationService.sendSms(phoneNumber);
+    this.reservationService.sendSms(phoneNumber);
     return ResponseEntity.ok(BasicResponse.builder()
-        .message("send sms code success").data(response).build());
+        .message("send sms code success").build());
   }
 
   @PostMapping("/sms/check")

--- a/api/src/main/java/grooteogi/dto/ReservationDto.java
+++ b/api/src/main/java/grooteogi/dto/ReservationDto.java
@@ -49,13 +49,6 @@ public class ReservationDto {
 
   @Data
   @Builder
-  public static class SendSmsResponse {
-
-    private String code;
-  }
-
-  @Data
-  @Builder
   public static class CheckSmsRequest {
 
     @NotBlank(message = "핸드폰 번호를 입력해주세요.")

--- a/api/src/main/java/grooteogi/service/ReservationService.java
+++ b/api/src/main/java/grooteogi/service/ReservationService.java
@@ -7,7 +7,6 @@ import grooteogi.domain.Schedule;
 import grooteogi.domain.User;
 import grooteogi.dto.ReservationDto;
 import grooteogi.dto.ReservationDto.CheckSmsRequest;
-import grooteogi.dto.ReservationDto.SendSmsResponse;
 import grooteogi.enums.ReservationStatus;
 import grooteogi.exception.ApiException;
 import grooteogi.exception.ApiExceptionEnum;
@@ -234,7 +233,7 @@ public class ReservationService {
     return ReservationMapper.INSTANCE.toResponseDto(modifiedReservation);
   }
 
-  public SendSmsResponse sendSms(String phoneNumber) {
+  public void sendSms(String phoneNumber) {
 
     Random rand = new Random();
     String numStr = String.format("%04d", rand.nextInt(10000));
@@ -242,8 +241,6 @@ public class ReservationService {
     smsClient.certifiedPhoneNumber(phoneNumber, numStr);
     String key = prefix + phoneNumber;
     redisClient.setValue(key, numStr, 3L);
-    return SendSmsResponse.builder()
-        .code(numStr).build();
   }
 
   public void checkSms(CheckSmsRequest request) {

--- a/api/src/test/java/grooteogi/ReservationDocumentationTests.java
+++ b/api/src/test/java/grooteogi/ReservationDocumentationTests.java
@@ -388,13 +388,8 @@ public class ReservationDocumentationTests {
   @DisplayName("연락처 문자 인증코드 전송")
   void sendSms() throws Exception {
 
-    final ReservationDto.SendSmsResponse response
-        = ReservationDto.SendSmsResponse.builder()
-        .code("ab12")
-        .build();
 
-    given(reservationService.sendSms(phoneNumber)).willReturn(response);
-
+    reservationService.sendSms(phoneNumber);
     ResultActions resultActions = mockMvc.perform(
         RestDocumentationRequestBuilders
             .post("/reservation/sms/send?phoneNumber={phoneNumber}", phoneNumber)
@@ -413,8 +408,7 @@ public class ReservationDocumentationTests {
                 ),
                 responseFields(
                     fieldWithPath("status").description("결과 코드"),
-                    fieldWithPath("message").description("응답 메세지"),
-                    fieldWithPath("data.code").description("인증코드")
+                    fieldWithPath("message").description("응답 메세지")
                 )
             )
         );


### PR DESCRIPTION
## Related Issue
[GRTG-394] sms 전송 시 인증 코드 리턴 수정
## Description
response 삭제하고 service에서 void로 바꿈!
## Changes

## Note


[GRTG-394]: https://babiyak.atlassian.net/browse/GRTG-394?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ