### PR TITLE
예약 조회 시, 호스트 유저 연락처 검증 로직 삭제

### DIFF
--- a/api/src/main/java/grooteogi/dto/ReservationDto.java
+++ b/api/src/main/java/grooteogi/dto/ReservationDto.java
@@ -32,7 +32,6 @@ public class ReservationDto {
     private int postId;
     private String imageUrl;
     private Boolean isCanceled;
-    private String hostPhone;
     private String applyPhone;
     private String applyNickname;
     private String text;

--- a/api/src/main/java/grooteogi/mapper/ReservationMapper.java
+++ b/api/src/main/java/grooteogi/mapper/ReservationMapper.java
@@ -40,7 +40,6 @@ public interface ReservationMapper extends BasicMapper<ReservationDto, Reservati
       @Mapping(target = "startTime", dateFormat = "HH:mm:ss"),
       @Mapping(target = "endTime", dateFormat = "HH:mm:ss"),
       @Mapping(target = "postId", source = "post.id"),
-      @Mapping(target = "hostPhone", source = "hostPhone"),
       @Mapping(target = "applyPhone", source = "applyPhone"),
       @Mapping(target = "isCanceled", source = "reservation.isCanceled"),
       @Mapping(target = "applyNickname", source = "applyNickname"),
@@ -50,7 +49,7 @@ public interface ReservationMapper extends BasicMapper<ReservationDto, Reservati
   })
   ReservationDto.DetailResponse toDetailResponseDto(Reservation reservation,
       Post post, Schedule schedule, Review review,
-      String hostPhone, String applyPhone, String applyNickname);
+      String applyPhone, String applyNickname);
 
   @Mapping(source = "isCanceled", target = "isCanceled")
   Reservation toModifyIsCanceled(Reservation reservation, boolean isCanceled);

--- a/api/src/main/java/grooteogi/service/ReservationService.java
+++ b/api/src/main/java/grooteogi/service/ReservationService.java
@@ -48,12 +48,9 @@ public class ReservationService {
         .orElseThrow(() -> new ApiException(ApiExceptionEnum.RESERVATION_NOT_FOUND_EXCEPTION));
     User participateUser = reservation.get().getParticipateUser();
 
-    Optional<String> hostUserPhone = Optional.ofNullable(
-        reservation.get().getHostUser().getUserInfo().getContact());
     Optional<String> participateUserPhone = Optional.ofNullable(
         participateUser.getUserInfo().getContact());
 
-    hostUserPhone.orElseThrow(() -> new ApiException(ApiExceptionEnum.CONTACT_NOT_FOUND_EXCEPTION));
     participateUserPhone
         .orElseThrow(() -> new ApiException(ApiExceptionEnum.CONTACT_NOT_FOUND_EXCEPTION));
 
@@ -67,7 +64,7 @@ public class ReservationService {
 
     return ReservationMapper.INSTANCE.toDetailResponseDto(
         reservation.get(), reservation.get().getSchedule().getPost(),
-        reservation.get().getSchedule(), review, hostUserPhone.get(),
+        reservation.get().getSchedule(), review,
         participateUserPhone.get(), participateUser.getNickname());
   }
 
@@ -120,13 +117,9 @@ public class ReservationService {
     List<ReservationDto.DetailResponse> responseList = new ArrayList<>();
     reservations.forEach(reservation -> {
 
-      Optional<String> hostUserPhone = Optional.ofNullable(
-          reservation.getHostUser().getUserInfo().getContact());
       Optional<String> participateUserPhone = Optional.ofNullable(
           reservation.getParticipateUser().getUserInfo().getContact());
 
-      hostUserPhone
-          .orElseThrow(() -> new ApiException(ApiExceptionEnum.CONTACT_NOT_FOUND_EXCEPTION));
       participateUserPhone
           .orElseThrow(() -> new ApiException(ApiExceptionEnum.CONTACT_NOT_FOUND_EXCEPTION));
 
@@ -145,7 +138,7 @@ public class ReservationService {
       ReservationDto.DetailResponse detailResponse =
           ReservationMapper.INSTANCE.toDetailResponseDto(
               reservation, reservation.getSchedule().getPost(), reservation.getSchedule(),
-              review, hostUserPhone.get(), participateUserPhone.get(), participateUserNickname);
+              review, participateUserPhone.get(), participateUserNickname);
       detailResponse.setHashtags(getTags(reservation.getSchedule().getPost().getPostHashtags()));
       responseList.add(detailResponse);
     });

--- a/api/src/test/java/grooteogi/ReservationDocumentationTests.java
+++ b/api/src/test/java/grooteogi/ReservationDocumentationTests.java
@@ -88,7 +88,6 @@ public class ReservationDocumentationTests {
           .isCanceled(true)
           .title("개발이 좋아?")
           .applyPhone("01012345678")
-          .hostPhone("01098765432")
           .text("잘부탁드려요.")
           .applyNickname("새내기")
           .review("리뷰 쓰기 싫어요")
@@ -142,7 +141,6 @@ public class ReservationDocumentationTests {
                     fieldWithPath("data.postId").description("포스트 ID"),
                     fieldWithPath("data.imageUrl").description("포스트 이미지 url"),
                     fieldWithPath("data.isCanceled").description("약속 취소 여부"),
-                    fieldWithPath("data.hostPhone").description("멘토 연락처"),
                     fieldWithPath("data.applyPhone").description("멘티 연락처"),
                     fieldWithPath("data.applyNickname").description("멘티 닉네임"),
                     fieldWithPath("data.text").description("호스트에게 남기는 말"),
@@ -197,7 +195,6 @@ public class ReservationDocumentationTests {
                     fieldWithPath("data.[].postId").description("포스트 ID"),
                     fieldWithPath("data.[].imageUrl").description("포스트 이미지 url"),
                     fieldWithPath("data.[].isCanceled").description("약속 취소 여부"),
-                    fieldWithPath("data.[].hostPhone").description("멘토 연락처"),
                     fieldWithPath("data.[].applyPhone").description("멘티 연락처"),
                     fieldWithPath("data.[].applyNickname").description("멘티 닉네임"),
                     fieldWithPath("data.[].text").description("호스트에게 남기는 말"),
@@ -252,7 +249,6 @@ public class ReservationDocumentationTests {
                     fieldWithPath("data.[].postId").description("포스트 ID"),
                     fieldWithPath("data.[].imageUrl").description("포스트 이미지 url"),
                     fieldWithPath("data.[].isCanceled").description("약속 취소 여부"),
-                    fieldWithPath("data.[].hostPhone").description("멘토 연락처"),
                     fieldWithPath("data.[].applyPhone").description("멘티 연락처"),
                     fieldWithPath("data.[].applyNickname").description("멘티 닉네임"),
                     fieldWithPath("data.[].text").description("호스트에게 남기는 말"),


### PR DESCRIPTION
## Related Issue
[GRTG-401](https://babiyak.atlassian.net/jira/software/c/projects/GRTG/boards/1/backlog?view=detail&selectedIssue=GRTG-401&issueLimit=100)
## Description
호스트 유저 연락처 검증 삭제
호스트 유저 연락처 response 에서 삭제